### PR TITLE
Fix GCC 4.7 compilation issues

### DIFF
--- a/src/overpass_api/osm-backend/generate_test_file.cc
+++ b/src/overpass_api/osm-backend/generate_test_file.cc
@@ -33,7 +33,7 @@ struct V : public vector< T >
   V(const T& t) : vector< T >(1, t) {}
   V& operator()(const T& t)
   {
-    push_back(t);
+    this->push_back(t);
     return *this;
   }
 };

--- a/src/overpass_api/osm-backend/generate_test_file_areas.cc
+++ b/src/overpass_api/osm-backend/generate_test_file_areas.cc
@@ -33,7 +33,7 @@ struct V : public vector< T >
   V(const T& t) : vector< T >(1, t) {}
   V& operator()(const T& t)
   {
-    push_back(t);
+    this->push_back(t);
     return *this;
   }
 };

--- a/src/overpass_api/osm-backend/generate_test_file_meta.cc
+++ b/src/overpass_api/osm-backend/generate_test_file_meta.cc
@@ -33,7 +33,7 @@ struct V : public vector< T >
   V(const T& t) : vector< T >(1, t) {}
   V& operator()(const T& t)
   {
-    push_back(t);
+    this->push_back(t);
     return *this;
   }
 };


### PR DESCRIPTION
Overpass has issues compiling w/ GCC 4.7. These commits fix issues I was able to find, which were apparently only in the tests.
