### PR TITLE
Accept generic type=boundary relations as areas

### DIFF
--- a/rules/areas.osm3s
+++ b/rules/areas.osm3s
@@ -3,11 +3,15 @@
 
 <union>
   <query type="relation">
-    <has-kv k="admin_level"/>
+    <has-kv k="type" v="multipolygon"/>
     <has-kv k="name"/>
   </query>
   <query type="relation">
-    <has-kv k="type" v="multipolygon"/>
+    <has-kv k="type" v="boundary"/>
+    <has-kv k="name"/>
+  </query>
+  <query type="relation">
+    <has-kv k="admin_level"/>
     <has-kv k="name"/>
   </query>
   <query type="relation">
@@ -254,3 +258,5 @@
 </foreach>
 
 </osm-script>
+
+    


### PR DESCRIPTION
type=[boundary](http://taginfo.openstreetmap.org/keys/boundary#values) relations are often used for protected areas, national parks, etc. This adds them to the Overpass-area generetion script.
