### PR TITLE
Updated statement dump for 0.7.50

### DIFF
--- a/src/overpass_api/statements/statement_dump.cc
+++ b/src/overpass_api/statements/statement_dump.cc
@@ -335,6 +335,8 @@ string Statement_Dump::dump_compact_map_ql() const
 	result += "[maxsize:" + it->second + "]";
       else if (it->first == "output")
 	result += "[out:" + it->second + "]";
+      else if (it->first == "bbox")
+	result += "[bbox:" + it->second + "]";
     }
 
     if (attributes.find("augmented") != attributes.end() && 
@@ -533,6 +535,8 @@ string Statement_Dump::dump_bbox_map_ql() const
 	result += "[maxsize:" + it->second + "]";
       else if (it->first == "output")
 	result += "[out:" + it->second + "]";
+      else if (it->first == "bbox")
+	result += "[bbox:" + it->second + "]";
     }
 
     if (attributes.find("augmented") != attributes.end() && 
@@ -733,6 +737,8 @@ string Statement_Dump::dump_pretty_map_ql() const
 	result += "[maxsize:" + it->second + "]\n";
       else if (it->first == "output")
 	result += "[out:" + it->second + "]\n";
+      else if (it->first == "bbox")
+	result += "[bbox:" + it->second + "]\n";
     }
 
     if (attributes.find("augmented") != attributes.end() && 


### PR DESCRIPTION
I started to add some of the missing features to the statement dump: date, diff, adiff, changed, difference, tags output mode, geometry, global bbox. Please review carefully before applying. Thanks!

Fixes #99 
Fixes #123
