### PR TITLE
update configure for automake 1.14

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -6,16 +6,16 @@ AC_INIT([OverpassAPI], [0.6.98], [roland.olbricht@gmx.de])
 AC_CONFIG_SRCDIR([template_db/file_blocks.h])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
-LT_INIT
+AM_INIT_AUTOMAKE([-Wall foreign])
+
 
 # Checks for programs.
+AM_PROG_AR
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_PROG_MAKE_SET
-AC_PROG_RANLIB
 
 # Checks for libraries.
 AC_CHECK_LIB([expat], [XML_Parse])


### PR DESCRIPTION
- fixes a warning about missing AM_PROG_AR
- makes warnings non fatal because 1.14 warns about the use of
  subdirectories
