### PR TITLE
Add Access-Control-Max-Age for CORS preflight headers

### DIFF
--- a/src/overpass_api/frontend/web_output.cc
+++ b/src/overpass_api/frontend/web_output.cc
@@ -138,7 +138,7 @@ void Web_Output::write_html_header
     }
     if (allow_headers != "")
       cout<<"Access-Control-Allow-Headers: "<<allow_headers<<'\n';
-    if (has_origin) 
+    if (has_origin)
       cout<<"Access-Control-Allow-Origin: *\n"
             "Access-Control-Max-Age: 600\n";
     if (http_method == http_options)
@@ -184,7 +184,7 @@ void Web_Output::write_xml_header
   {
     if (allow_headers != "")
       cout<<"Access-Control-Allow-Headers: "<<allow_headers<<'\n';
-    if (has_origin) 
+    if (has_origin)
       cout<<"Access-Control-Allow-Origin: *\n"
             "Access-Control-Max-Age: 600\n";
     if (http_method == http_options)
@@ -216,7 +216,7 @@ void Web_Output::write_json_header
   {
     if (allow_headers != "")
       cout<<"Access-Control-Allow-Headers: "<<allow_headers<<'\n';
-    if (has_origin) 
+    if (has_origin)
       cout<<"Access-Control-Allow-Origin: *\n"
             "Access-Control-Max-Age: 600\n";
     if (http_method == http_options)
@@ -255,7 +255,7 @@ void Web_Output::write_text_header
   {
     if (allow_headers != "")
       cout<<"Access-Control-Allow-Headers: "<<allow_headers<<'\n';
-    if (has_origin) 
+    if (has_origin)
       cout<<"Access-Control-Allow-Origin: *\n"
             "Access-Control-Max-Age: 600\n";
     if (http_method == http_options)


### PR DESCRIPTION
Currently, the browser needs to make two request for each Overpass API call in a CORS scenario: one for the OPTIONS preflight check and eventually the POST/GET. For interactive maps with several layers this creates a large number of additional requests.

This pull request adds an Access-Control-Max-Age HTTP response header with a timeout of 600 seconds (10 minutes), which allows the browser to cache the preflight options request and help improve performance for interactive maps.

Tested with firefox and chrome on local Overpass API installation.

[More details...](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
