### PR TITLE
Output global bbox to JSON

### DIFF
--- a/src/overpass_api/frontend/print_target.cc
+++ b/src/overpass_api/frontend/print_target.cc
@@ -1725,6 +1725,19 @@ void Output_Handle::print_bounds(double south, double west, double north, double
   if (type == "xml")
     cout<<"  <bounds minlat=\""<<south<<"\" minlon=\""<<west<<"\" "
           "maxlat=\""<<north<<"\" maxlon=\""<<east<<"\"/>\n\n";
+  else if (type == "json")
+    cout<<"  \"bounds\": {\n"
+          "    \"minlat\": " << south << ",\n"
+          "    \"minlon\": " << west  << ",\n"
+          "    \"maxlat\": " << north << ",\n"
+          "    \"maxlon\": " << east  << "\n"
+          "  },\n";
+}
+
+void Output_Handle::print_elements_header()
+{
+  if (type == "json")
+    cout<< "  \"elements\": [\n\n";
 }
 
 

--- a/src/overpass_api/frontend/print_target.h
+++ b/src/overpass_api/frontend/print_target.h
@@ -55,6 +55,7 @@ class Output_Handle
     void set_categories(const vector< Category_Filter >& categories_) { categories = categories_; }
     
     void print_bounds(double south, double west, double north, double east);
+    void print_elements_header();
 
   private:
     string type;

--- a/src/overpass_api/frontend/web_output.cc
+++ b/src/overpass_api/frontend/web_output.cc
@@ -236,8 +236,8 @@ void Web_Output::write_json_header
     cout<<"    \"timestamp_areas_base\": \""<<area_timestamp<<"\",\n";
   cout<<"    \"copyright\": \"The data included in this document is from www.openstreetmap.org."
 	" The data is made available under ODbL.\"\n"
-        "  },\n"
-        "  \"elements\": [\n\n";
+        "  },\n";
+//  cout<< "  \"elements\": [\n\n";
 }
 
 

--- a/src/overpass_api/statements/osm_script.cc
+++ b/src/overpass_api/statements/osm_script.cc
@@ -350,6 +350,8 @@ void Osm_Script_Statement::execute(Resource_Manager& rman)
     if (bbox_statement)
       output_handle->print_bounds(bbox_statement->get_south(), bbox_statement->get_west(),
                                   bbox_statement->get_north(), bbox_statement->get_east());
+
+    output_handle->print_elements_header();
   }
   
   if (comparison_timestamp > 0)


### PR DESCRIPTION
First attempt to address issue #74.

 **There's one thing which deserves closer attention**: Printing out the initial "elements" tag moved from write_json_header to print_elements_header in frontend/print_target.cc.

I did a number of tests with osm-script/ql and json and they looked good so far. But I'm not 100% sure if there's some use case where write_json_header is called, but not the new method print_elements_header. This would result in invalid json, as Web_Output::write_footer would assume an opening "elements" tag in any case, which is then missing.

In any case this patch might need some rework... feedback welcome!

Fixes #74 
