### PR TITLE
out:csv - added missing display_error + display_remark

### DIFF
--- a/src/overpass_api/frontend/web_output.cc
+++ b/src/overpass_api/frontend/web_output.cc
@@ -316,6 +316,8 @@ void Web_Output::display_remark(const string& text)
   else if (header_written == html)
     cout<<"<p><strong style=\"color:#00BB00\">Remark</strong>: "
         <<text<<" </p>\n";
+  else if (header_written == csv)
+    cout<<"Remark: "<<text<<"\n";
 }
 
 void Web_Output::display_error(const string& text, uint write_mime)
@@ -330,4 +332,6 @@ void Web_Output::display_error(const string& text, uint write_mime)
         <<text<<" </p>\n";
   else if (header_written == json)
     messages += text;
+  else if (header_written == csv)
+    cout<<"Remark: "<<text<<"\n";
 }


### PR DESCRIPTION
Patch addresses missing display_error and display_remark in case of out:csv mode. Especially in the case of timeouts, missing error messages are rather confusing for a user, hence this should probably go into 0.7.51 before releasing.

Thanks!
