### PR TITLE
Name nameless stops from their stop_area relation

### DIFF
--- a/src/pt_diagrams/processed_input.h
+++ b/src/pt_diagrams/processed_input.h
@@ -74,6 +74,7 @@ struct Relation
     vector< unsigned int > forward_stops;
     vector< unsigned int > backward_stops;
     
+    string name;
     string ref;
     string network;
     string color;

--- a/src/pt_diagrams/processed_input.h
+++ b/src/pt_diagrams/processed_input.h
@@ -68,7 +68,7 @@ struct Timespan
 struct Relation
 {
   public:
-    Relation() : forward_stops(), backward_stops(), ref(""), network(""),
+    Relation() : forward_stops(), backward_stops(), name(""), ref(""), network(""),
       color(""), from(""), to(""), direction(0), opening_hours() {}
     
     vector< unsigned int > forward_stops;


### PR DESCRIPTION
As documented here: https://wiki.openstreetmap.org/wiki/Tag:public_transport%3Dstop_position
and here: https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbus_stop
the stop_area can carry a name valid for its members.

I implemented using the stop_area name for recognised stop members without a name. I think this was intended to reduce the need for double tagging stop_areas and their members.

Its just about to show names, and make their absence appear less as an error in data. 

Please review / comment.
