### PR TITLE
Extended polygon statement - nodes inside a closed way

### DIFF
--- a/src/overpass_api/frontend/map_ql_parser.cc
+++ b/src/overpass_api/frontend/map_ql_parser.cc
@@ -504,7 +504,7 @@ TStatement* create_polygon_statement(typename TStatement::Factory& stmt_factory,
 				   string bounds, string from, string into, uint line_nr)
 {
   map< string, string > attr;
-  attr["from"] = from;
+  attr["from"] = (from == "" ? "_" : from);
   attr["bounds"] = bounds;
   attr["into"] = into;
   return stmt_factory.create_statement("polygon-query", line_nr, attr);

--- a/src/overpass_api/statements/polygon_query.cc
+++ b/src/overpass_api/statements/polygon_query.cc
@@ -233,6 +233,7 @@ Polygon_Query_Statement::Polygon_Query_Statement
 {
   map< string, string > attributes;
   
+  attributes["from"] = "_";
   attributes["into"] = "_";
   attributes["bounds"] = "";
   
@@ -240,8 +241,23 @@ Polygon_Query_Statement::Polygon_Query_Statement
   
   set_output(attributes["into"]);
   
+  if (attributes["bounds"] != "")
+    convert_bounds(attributes["bounds"]);
+
+}
+
+
+Polygon_Query_Statement::~Polygon_Query_Statement()
+{
+  for (vector< Query_Constraint* >::const_iterator it = constraints.begin();
+      it != constraints.end(); ++it)
+    delete *it;
+}
+
+void Polygon_Query_Statement::convert_bounds(string bounds)
+{
   //convert bounds
-  istringstream in(attributes["bounds"]);
+  istringstream in(bounds);
   vector<double> v = vector<double>(istream_iterator<double>(in), istream_iterator<double>());
   if (v.size() % 2)
   {
@@ -308,14 +324,6 @@ Polygon_Query_Statement::Polygon_Query_Statement
   sort(segments.begin(), segments.end());
 
   add_segment_blocks(segments);
-}
-
-
-Polygon_Query_Statement::~Polygon_Query_Statement()
-{
-  for (vector< Query_Constraint* >::const_iterator it = constraints.begin();
-      it != constraints.end(); ++it)
-    delete *it;
 }
 
 

--- a/src/overpass_api/statements/polygon_query.cc
+++ b/src/overpass_api/statements/polygon_query.cc
@@ -64,6 +64,9 @@ bool Polygon_Constraint::delivers_data(Resource_Manager& rman)
 bool Polygon_Constraint::get_ranges
     (Resource_Manager& rman, set< pair< Uint32_Index, Uint32_Index > >& ranges)
 {
+  if (polygon->polygons_from_inputset())
+    polygon->convert_inputset(rman);
+
   ranges = polygon->calc_ranges();
   return true;
 }
@@ -72,9 +75,13 @@ bool Polygon_Constraint::get_ranges
 bool Polygon_Constraint::get_ranges
     (Resource_Manager& rman, set< pair< Uint31_Index, Uint31_Index > >& ranges)
 {
+  if (polygon->polygons_from_inputset())
+    polygon->convert_inputset(rman);
+
   set< pair< Uint32_Index, Uint32_Index > > node_ranges = polygon->calc_ranges();
   ranges = calc_parents(node_ranges);
   return true;
+
 }
 
 
@@ -240,7 +247,10 @@ Polygon_Query_Statement::Polygon_Query_Statement
   eval_attributes_array(get_name(), attributes, input_attributes);
   
   set_output(attributes["into"]);
-  
+
+  input = attributes["from"];
+  has_bounds = (attributes["bounds"] != "");
+
   if (attributes["bounds"] != "")
     convert_bounds(attributes["bounds"]);
 
@@ -537,6 +547,16 @@ void Polygon_Query_Statement::collect_ways
   result.swap(ways);
 }
 
+void Polygon_Query_Statement::convert_inputset(Resource_Manager& rman)
+{
+  map< string, Set >::const_iterator mit = rman.sets().find(get_input());
+  if (mit == rman.sets().end())
+    return;
+
+  segments.clear();
+// TODO
+
+}
 
 void Polygon_Query_Statement::execute(Resource_Manager& rman)
 {

--- a/src/overpass_api/statements/polygon_query.h
+++ b/src/overpass_api/statements/polygon_query.h
@@ -53,6 +53,8 @@ class Polygon_Query_Statement : public Output_Statement
        const Way_Geometry_Store& way_geometries,
        bool add_border, const Statement& query, Resource_Manager& rman);
 
+    void convert_bounds(string bounds);
+
   private:
     unsigned int type;
     vector< Aligned_Segment > segments;

--- a/src/overpass_api/statements/polygon_query.h
+++ b/src/overpass_api/statements/polygon_query.h
@@ -53,10 +53,17 @@ class Polygon_Query_Statement : public Output_Statement
        const Way_Geometry_Store& way_geometries,
        bool add_border, const Statement& query, Resource_Manager& rman);
 
+    string get_input() const { return input; }
+
+    bool polygons_from_inputset() const { return (!has_bounds); }
+
     void convert_bounds(string bounds);
+    void convert_inputset(Resource_Manager& rman);
 
   private:
+    string input;
     unsigned int type;
+    bool has_bounds;
     vector< Aligned_Segment > segments;
     vector< Query_Constraint* > constraints;
 };

--- a/src/overpass_api/statements/polygon_query.h
+++ b/src/overpass_api/statements/polygon_query.h
@@ -61,6 +61,8 @@ class Polygon_Query_Statement : public Output_Statement
     void convert_inputset(Resource_Manager& rman);
 
   private:
+    static Node::Id_Type check_node_parity(const Set& pivot);
+
     string input;
     unsigned int type;
     bool has_bounds;

--- a/src/overpass_api/statements/statement_dump.cc
+++ b/src/overpass_api/statements/statement_dump.cc
@@ -314,6 +314,15 @@ string dump_subquery_map_ql(const string& name, const map< string, string >& att
       result += ":" + attributes.find("ref")->second;
     result += ")";
   }
+  else if (name == "polygon-query")
+  {
+    result += "(poly";
+    if (attributes.find("from") != attributes.end() && attributes.find("from")->second != "_")
+      result += "." + attributes.find("from")->second;
+    if (attributes.find("bounds") != attributes.end() && attributes.find("bounds")->second != "")
+      result += ":\"" + attributes.find("bounds")->second + "\"";
+    result += ")";
+  }
   else
     result += "(" + name + ":)";
   
@@ -505,6 +514,16 @@ string Statement_Dump::dump_compact_map_ql() const
   {
     result += "node" + dump_subquery_map_ql(name_, attributes);
     
+    if (attributes.find("into") != attributes.end() && attributes.find("into")->second != "_")
+      result += "->." + attributes.find("into")->second;
+  }
+  else if (name_ == "polygon-query")
+  {
+    result += "node";
+    result += attributes.find("type")->second;
+
+    result += dump_subquery_map_ql(name_, attributes);
+
     if (attributes.find("into") != attributes.end() && attributes.find("into")->second != "_")
       result += "->." + attributes.find("into")->second;
   }
@@ -711,6 +730,14 @@ string Statement_Dump::dump_bbox_map_ql() const
   {
     result += "node" + dump_subquery_map_ql(name_, attributes) + "(bbox)";
     
+    if (attributes.find("into") != attributes.end() && attributes.find("into")->second != "_")
+      result += "->." + attributes.find("into")->second;
+  }
+  else if (name_ == "polygon-query")
+  {
+    result += "node";
+    result += dump_subquery_map_ql(name_, attributes);
+
     if (attributes.find("into") != attributes.end() && attributes.find("into")->second != "_")
       result += "->." + attributes.find("into")->second;
   }
@@ -926,6 +953,14 @@ string Statement_Dump::dump_pretty_map_ql() const
   {
     result += "node" + dump_subquery_map_ql(name_, attributes);
     
+    if (attributes.find("into") != attributes.end() && attributes.find("into")->second != "_")
+      result += "->." + attributes.find("into")->second;
+  }
+  else if (name_ == "polygon-query")
+  {
+    result += "node";
+    result += dump_subquery_map_ql(name_, attributes);
+
     if (attributes.find("into") != attributes.end() && attributes.find("into")->second != "_")
       result += "->." + attributes.find("into")->second;
   }


### PR DESCRIPTION
**This pull request needs a concept review, don't merge yet**

This pull request aims at closing the gap between the current lat/lon pair based polygon statement and the area statement, which isn't available for all osm objects. Furthermore, I've added a statement dump implementation for `polygon`. A few use cases are also provided in #77. 

This PR may need quite some cleanup. Especially method convert_inputset has a few calls to other methods I've taken over from make_area.cc. Not sure if this all makes sense.

Related threads on help.openstreetmap.org:

https://help.openstreetmap.org/questions/19914/overpass-polygon-query
https://help.openstreetmap.org/questions/20841/how-to-query-all-elements-within-an-outline-way-from-overpass-api

Fixes #77 --- **caveat: still some open topics, see ticket #77.**
