### PR TITLE
out count: added # of areas in xml mode

### DIFF
--- a/src/overpass_api/frontend/print_target.cc
+++ b/src/overpass_api/frontend/print_target.cc
@@ -674,7 +674,8 @@ void Print_Target_Xml::print_item_count(const Output_Item_Count& item_count)
   cout<<"  <count total=\"" << item_count.total << "\" "
         "nodes=\"" << item_count.nodes << "\" "
         "ways=\"" << item_count.ways << "\" "
-        "relations=\"" << item_count.relations << "\"/>\n";
+        "relations=\"" << item_count.relations << "\" "
+        "areas=\"" << item_count.areas << "\"/>\n";
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
`out count;` didn't show the number of areas in XML mode. This is now fixed in this pull request.

New output:

``` XML
  <count total="2" nodes="0" ways="0" relations="0" areas="2"/>
  <count total="5" nodes="5" ways="0" relations="0" areas="0"/>
```
