### PR TITLE
reconstruct_items: timestamp_by_id for results only

### DIFF
--- a/src/overpass_api/data/collect_items.h
+++ b/src/overpass_api/data/collect_items.h
@@ -51,10 +51,10 @@ void reconstruct_items(const Statement* stmt, Resource_Manager& rman,
       if (stmt)
         rman.health_check(*stmt, 0, eval_map(result));
     }
-    if (timestamp < timestamp_of(it.object()))
+    if (timestamp < timestamp_of(it.object()) &&
+        predicate.match(it.object()))
     {
-      timestamp_by_id.push_back(std::make_pair(it.object().id, timestamp_of(it.object())));
-      if (predicate.match(it.object()))
+        timestamp_by_id.push_back(std::make_pair(it.object().id, timestamp_of(it.object())));
         result[it.index()].push_back(it.object());
     }
   }


### PR DESCRIPTION
`reconstruct_items` collects id/timestamp pairs in `timestamp_by_id` regardless of `predicate.match`. However, `filter_items_by_timestamp` (which is called later by `collect_items_by_timestamp`) seems to only consider timestamp_by_id entries for ids contained in `(attic_)result`. For the test case below, this causes a huge memory consumption in excess of 3GB. 

This pull request changes this logic, so that `timestamp_by_id` will only be filled, if the id is also in `result`.

Test case:

``` C
[date:"2014-09-25T00:00:00Z"]
[timeout:600];
area["name:de"="Deutschland"]
    [boundary=administrative];
node(area)[railway=switch];
out count;
```
