### PR TITLE
Bbox query ignores ways with just one node 

### DIFF
--- a/src/overpass_api/statements/bbox_query.cc
+++ b/src/overpass_api/statements/bbox_query.cc
@@ -139,6 +139,21 @@ bool matches_bbox(const Bbox_Query_Statement& bbox, const vector< Quad_Coord >& 
   vector< Quad_Coord >::const_iterator nit = way_geometry.begin();
   if (nit == way_geometry.end())
     return false;
+
+  // ways with single node only
+  if (way_geometry.size() == 1)
+  {
+    double lat(::lat(nit->ll_upper, nit->ll_lower));
+    double lon(::lon(nit->ll_upper, nit->ll_lower));
+    if ((lat >= bbox.get_south()) && (lat <= bbox.get_north()) &&
+        (((lon >= bbox.get_west()) && (lon <= bbox.get_east()))
+          || ((bbox.get_east() < bbox.get_west()) &&
+              ((lon >= bbox.get_west()) || (lon <= bbox.get_east())))))
+      return true;
+
+    return false;
+  }
+
   double first_lat(::lat(nit->ll_upper, nit->ll_lower));
   double first_lon(::lon(nit->ll_upper, nit->ll_lower));
   for (++nit; nit != way_geometry.end(); ++nit)


### PR DESCRIPTION
Fixes #193 - was reported in OSM Forum.