### PR TITLE
Multiple user support for (user:...) and (uid:...).

### DIFF
--- a/src/overpass_api/frontend/map_ql_parser.cc
+++ b/src/overpass_api/frontend/map_ql_parser.cc
@@ -521,22 +521,28 @@ TStatement* create_user_statement
   attr["into"] = into;
 
   if (uid.empty())
-    attr["uid"] = "0";
+    attr["uid"] = "";
 
   if (name.empty())
     attr["name"] = "";
 
-  for(it = name.begin(), i = 0 ; it != name.end(); ++it, ++i)
+  for(it = name.begin(), i = 0; it != name.end(); ++it, ++i)
   {
     std::stringstream id;
-    id << "name_" << i;
+    if (i == 0)
+      id << "name";
+    else
+      id << "name_" << i;
     attr[id.str()] = *it;
   }
 
-  for(it = uid.begin(), i = 0 ; it != uid.end(); ++it, ++i)
+  for(it = uid.begin(), i = 0; it != uid.end(); ++it, ++i)
   {
     std::stringstream id;
-    id << "uid_" << i;
+    if (i == 0)
+      id << "uid";
+    else
+      id << "uid_" << i;
     attr[id.str()] = *it;
   }
 

--- a/src/overpass_api/statements/user.cc
+++ b/src/overpass_api/statements/user.cc
@@ -52,7 +52,7 @@ class User_Constraint : public Query_Constraint
 template< typename TIndex, typename TObject >
 void user_filter_map
     (map< TIndex, vector< TObject > >& modify,
-     Resource_Manager& rman, uint32 user_id, File_Properties* file_properties)
+     Resource_Manager& rman, set< Uint32_Index > user_ids, File_Properties* file_properties)
 {
   if (modify.empty())
     return;
@@ -69,7 +69,7 @@ void user_filter_map
     {
       const OSM_Element_Metadata_Skeleton< typename TObject::Id_Type >* meta_skel
 	  = meta_collector.get(it->first, iit->id);
-      if ((meta_skel) && (meta_skel->user_id == user_id))
+      if ((meta_skel) && (user_ids.find(meta_skel->user_id) != user_ids.end()))
 	local_into.push_back(*iit);
     }
     it->second.swap(local_into);
@@ -80,7 +80,7 @@ void user_filter_map
 template< typename TIndex, typename TObject >
 void user_filter_map_attic
     (map< TIndex, vector< TObject > >& modify,
-     Resource_Manager& rman, uint32 user_id,
+     Resource_Manager& rman, set< Uint32_Index > user_ids,
      File_Properties* current_file_properties, File_Properties* attic_file_properties)
 {
   if (modify.empty())
@@ -102,7 +102,7 @@ void user_filter_map_attic
 	  = current_meta_collector.get(it->first, iit->id);
       if (!meta_skel || !(meta_skel->timestamp < iit->timestamp))
         meta_skel = attic_meta_collector.get(it->first, iit->id, iit->timestamp);
-      if ((meta_skel) && (meta_skel->user_id == user_id))
+      if ((meta_skel) && (user_ids.find(meta_skel->user_id) != user_ids.end()))
 	local_into.push_back(*iit);
     }
     it->second.swap(local_into);
@@ -112,19 +112,19 @@ void user_filter_map_attic
 
 void User_Constraint::filter(const Statement& query, Resource_Manager& rman, Set& into, uint64 timestamp)
 {
-  uint32 user_id = user->get_id(*rman.get_transaction());
+  set< Uint32_Index > user_ids = user->get_ids(*rman.get_transaction());
   
-  user_filter_map(into.nodes, rman, user_id, meta_settings().NODES_META);
-  user_filter_map(into.ways, rman, user_id, meta_settings().WAYS_META);
-  user_filter_map(into.relations, rman, user_id, meta_settings().RELATIONS_META);
+  user_filter_map(into.nodes, rman, user_ids, meta_settings().NODES_META);
+  user_filter_map(into.ways, rman, user_ids, meta_settings().WAYS_META);
+  user_filter_map(into.relations, rman, user_ids, meta_settings().RELATIONS_META);
   
   if (timestamp != NOW)
   {
-    user_filter_map_attic(into.attic_nodes, rman, user_id,
+    user_filter_map_attic(into.attic_nodes, rman, user_ids,
 			  meta_settings().NODES_META, attic_settings().NODES_META);
-    user_filter_map_attic(into.attic_ways, rman, user_id,
+    user_filter_map_attic(into.attic_ways, rman, user_ids,
 			  meta_settings().WAYS_META, attic_settings().WAYS_META);
-    user_filter_map_attic(into.attic_relations, rman, user_id,
+    user_filter_map_attic(into.attic_relations, rman, user_ids,
 			  meta_settings().RELATIONS_META, attic_settings().RELATIONS_META);
   }
   
@@ -148,18 +148,50 @@ User_Statement::User_Statement
   attributes["name"] = "";
   attributes["type"] = "";
   
+  for (map<string, string>::const_iterator it = input_attributes.begin();
+      it != input_attributes.end(); ++it)
+  {
+    if (it->first.find("name_") == 0 ||
+        it->first.find("uid_")  == 0)
+      attributes[it->first] = "";
+  }
+
   eval_attributes_array(get_name(), attributes, input_attributes);
   
   set_output(attributes["into"]);
-  user_name = attributes["name"];
-  user_id = atoll(attributes["uid"].c_str());
-  if (((user_id == 0) && (user_name == "")) ||
-      ((user_id != 0) && (user_name != "")))
+
+  string user_name = attributes["name"];
+  uint32 user_id = atoll(attributes["uid"].c_str());
+
+  if (user_name != "")
+    user_names.insert(user_name);
+
+  if (user_id != 0)
+    user_ids.insert(user_id);
+
+  for (std::map<string, string>::iterator it = attributes.begin();
+      it != attributes.end(); ++it)
+  {
+    if (it->first.find("name_") == 0)
+    {
+      if (it->second != "")
+        user_names.insert(it->second);
+    }
+    if (it->first.find("uid_") == 0)
+    {
+      user_id = atoll(it->second.c_str());
+      if (user_id != 0)
+        user_ids.insert(user_id);
+    }
+  }
+
+  if (!(user_ids.empty() ^ user_names.empty()))
   {
     ostringstream temp;
     temp<<"Exactly one of the two attributes \"name\" and \"uid\" must be set.";
     add_static_error(temp.str());
   }
+
   result_type = attributes["type"];
 }
 
@@ -172,41 +204,41 @@ User_Statement::~User_Statement()
 }
 
 
-uint32 get_user_id(const string& user_name, Transaction& transaction)
+set< Uint32_Index > get_user_ids(const set< string >& user_names, Transaction& transaction)
 {
+  set< Uint32_Index > ids;
+
   Block_Backend< Uint32_Index, User_Data > user_db
       (transaction.data_index(meta_settings().USER_DATA));
   for (Block_Backend< Uint32_Index, User_Data >::Flat_Iterator
       user_it = user_db.flat_begin(); !(user_it == user_db.flat_end()); ++user_it)
   {
-    if (user_it.object().name == user_name)
-      return user_it.object().id;
+    if (user_names.find(user_it.object().name) != user_names.end())
+      ids.insert(user_it.object().id);
   }
-  return numeric_limits< uint32 >::max();
+  return ids;
 }
 
 
-uint32 User_Statement::get_id(Transaction& transaction)
+set< Uint32_Index > User_Statement::get_ids(Transaction& transaction)
 {
-  if (user_name != "")
-    user_id = get_user_id(user_name, transaction);  
+  if (!user_names.empty())
+    user_ids = get_user_ids(user_names, transaction);
   
-  return user_id;
+  return user_ids;
 }
 
 
 void calc_ranges
   (set< pair< Uint32_Index, Uint32_Index > >& node_req,
    set< pair< Uint31_Index, Uint31_Index > >& other_req,
-   uint32 user_id, Transaction& transaction)
+   set< Uint32_Index > user_ids, Transaction& transaction)
 {
-  set< Uint32_Index > req;
-  req.insert(user_id);
   
   Block_Backend< Uint32_Index, Uint31_Index > user_db
       (transaction.data_index(meta_settings().USER_INDICES));
   for (Block_Backend< Uint32_Index, Uint31_Index >::Discrete_Iterator
-      user_it = user_db.discrete_begin(req.begin(), req.end());
+      user_it = user_db.discrete_begin(user_ids.begin(), user_ids.end());
       !(user_it == user_db.discrete_end()); ++user_it)
   {
     if ((user_it.object().val() & 0x80000000) == 0)
@@ -230,7 +262,7 @@ bool User_Constraint::get_ranges
     (Resource_Manager& rman, set< pair< Uint32_Index, Uint32_Index > >& ranges)
 {
   set< pair< Uint31_Index, Uint31_Index > > nonnodes;
-  calc_ranges(ranges, nonnodes, user->get_id(*rman.get_transaction()), *rman.get_transaction());
+  calc_ranges(ranges, nonnodes, user->get_ids(*rman.get_transaction()), *rman.get_transaction());
   return true;
 }
 
@@ -239,7 +271,7 @@ bool User_Constraint::get_ranges
     (Resource_Manager& rman, set< pair< Uint31_Index, Uint31_Index > >& ranges)
 {
   set< pair< Uint32_Index, Uint32_Index > > nodes;
-  calc_ranges(nodes, ranges, user->get_id(*rman.get_transaction()), *rman.get_transaction());
+  calc_ranges(nodes, ranges, user->get_ids(*rman.get_transaction()), *rman.get_transaction());
   return true;
 }
 
@@ -249,10 +281,10 @@ void User_Statement::calc_ranges
      set< pair< Uint31_Index, Uint31_Index > >& other_req,
      Transaction& transaction)
 {
-  if (user_name != "")
-    user_id = get_user_id(user_name, transaction);  
+  if (!user_names.empty())
+    user_ids = get_user_ids(user_names, transaction);
 
-  ::calc_ranges(node_req, other_req, user_id, transaction);
+  ::calc_ranges(node_req, other_req, user_ids, transaction);
 }
 
 

--- a/src/overpass_api/statements/user.h
+++ b/src/overpass_api/statements/user.h
@@ -46,15 +46,15 @@ class User_Statement : public Output_Statement
          Transaction& transaction);
 	 
     // Reads the user id from the database.
-    uint32 get_id(Transaction& transaction);
+    set< Uint32_Index > get_ids(Transaction& transaction);
     
     // Works only if get_id(Transaction&) has been called before.
-    uint32 get_id() const { return user_id; }
+    set< Uint32_Index > get_ids() const { return user_ids; }
     
   private:
     string input;
-    uint32 user_id;
-    string user_name;
+    set< Uint32_Index > user_ids;
+    set< string > user_names;
     string result_type;
     vector< Query_Constraint* > constraints;
 };


### PR DESCRIPTION
**Motivation**

> It would be useful to extend the user statement to work with a multi-user input list. Espacially when removing prominent users via difference statement from the input statement.

(see #112)

**Current status**

The following query to find newbie mappers doesn't really scale that well to an ever increasing number of power users: http://www.openstreetmap.org/user/Nakaner/diary/35529. 

**Change introduced in this pull request**

This pull requests allows multiple users or uid in one filter. Mutiple users names or uids are separated by comma.

**Example for testing**

Task: Identify nodes which haven't been created by a group of known 'power users'.

Before:

```C
(.newnodes; - node.newnodes(user:Nakaner);)->.newnodes;
(.newnodes; - node.newnodes(user:"Nakaner-repair");)->.newnodes;
(.newnodes; - node.newnodes(user:bigbug21);)->.newnodes;
(.newnodes; - node.newnodes(user:mapper999);)->.newnodes;
```
After:

```C
( .newnodes; - node.newnodes(user:Nakaner, "Nakaner-repair", bigbug21, mapper999); );
```

The following shortlink can be used for testing the feature on the dev instance: http://overpass-turbo.eu/s/aY9

**TODOs**

* Please review and add comments below or directly in the source code.
* Adjustments in statement_dump to handle multiple uid/users