### PR TITLE
Delta mode for area creation (#141)

### DIFF
--- a/rules/areas_delta.osm3s
+++ b/rules/areas_delta.osm3s
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm-script timeout="86400" element-limit="2073741824">
+
+<union>
+  <query type="relation">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="type" v="multipolygon"/>
+    <has-kv k="name"/>
+  </query>
+  <query type="relation">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="type" v="boundary"/>
+    <has-kv k="name"/>
+  </query>
+  <query type="relation">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="admin_level"/>
+    <has-kv k="name"/>
+  </query>
+  <query type="relation">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="postal_code"/>
+  </query>
+  <query type="relation">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="addr:postcode"/>
+  </query>
+</union>
+<foreach into="pivot">
+  <union>
+    <recurse type="relation-way" from="pivot"/>
+    <recurse type="way-node"/>
+  </union>
+  <make-area pivot="pivot"/>
+</foreach>
+<union>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="area" v="yes"/>
+    <has-kv k="name"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="building"/>
+    <has-kv k="building" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="highway" v="services"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="highway" v="rest_area"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="highway" v="escape"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="natural"/>
+    <has-kv k="natural" v="no" modv="not"/>
+    <has-kv k="natural" v="coastline" modv="not"/>
+    <has-kv k="natural" v="ridge" modv="not"/>
+    <has-kv k="natural" v="arete" modv="not"/>
+    <has-kv k="natural" v="tree_row" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="landuse"/>
+    <has-kv k="landuse" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="waterway" v="riverbank"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="waterway" v="dock"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="waterway" v="boatyard"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="waterway" v="dam"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="amenity"/>
+    <has-kv k="amenity" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="leisure"/>
+    <has-kv k="leisure" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="barrier" v="city_wall"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="barrier" v="ditch"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="barrier" v="hedge"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="barrier" v="retaining_wall"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="barrier" v="wall"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="barrier" v="spikes"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="railway" v="station"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="railway" v="turntable"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="railway" v="roundhouse"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="railway" v="platform"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="boundary"/>
+    <has-kv k="boundary" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="man_made"/>
+    <has-kv k="man_made" v="no" modv="not"/>
+    <has-kv k="man_made" v="cutline" modv="not"/>
+    <has-kv k="man_made" v="embankment" modv="not"/>
+    <has-kv k="man_made" v="pipeline" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="power" v="generator"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="power" v="station"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="power" v="sub_station"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="power" v="transformer"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="place"/>
+    <has-kv k="place" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="shop"/>
+    <has-kv k="shop" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="aeroway"/>
+    <has-kv k="aeroway" v="no" modv="not"/>
+    <has-kv k="aeroway" v="taxiway" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="tourism"/>
+    <has-kv k="tourism" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="historic"/>
+    <has-kv k="historic" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="public_transport"/>
+    <has-kv k="public_transport" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="office"/>
+    <has-kv k="office" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="building:part"/>
+    <has-kv k="building:part" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="military"/>
+    <has-kv k="military" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
+    <changed since="{{area_version}}" until="{{area_version}}"/>
+    <has-kv k="craft"/>
+    <has-kv k="craft" v="no" modv="not"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+</union>
+<foreach into="pivot">
+  <union>
+    <item set="pivot"/>
+    <recurse type="way-node" from="pivot"/>
+  </union>
+  <make-area pivot="pivot"/>
+</foreach>
+
+</osm-script>
+
+    

--- a/src/bin/rules_delta_loop.sh
+++ b/src/bin/rules_delta_loop.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2008, 2009, 2010, 2011, 2012 Roland Olbricht
+#
+# This file is part of Overpass_API.
+#
+# Overpass_API is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Overpass_API is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
+
+if [[ -z $1  ]]; then
+{
+  echo Usage: $0 database_dir
+  exit 0
+};
+fi
+
+DB_DIR=$1
+
+EXEC_DIR="`dirname $0`/"
+if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
+{
+  EXEC_DIR="`pwd`/$EXEC_DIR"
+};
+fi
+
+pushd "$EXEC_DIR"
+
+while [[ true ]]; do
+{
+  echo "`date '+%F %T'`: update started" >>$DB_DIR/rules_loop.log
+  sed "s/{{area_version}}/$(cat $DB_DIR/area_version)/g" $DB_DIR/rules/areas_delta.osm3s | ./osm3s_query --progress --rules
+  echo "`date '+%F %T'`: update finished" >>$DB_DIR/rules_loop.log
+  sleep 3600
+}; done


### PR DESCRIPTION
Attic/Delta based Area updates.

This PR includes 
* an enhanced rules file with `{{area_version}}` as a placeholder. 
* a new script rules_delta_loop.sh, which can be scheduled once the Areas have been set up with a full run.

Maybe we could also have a unified rules file instead and remove `    <changed since="{{area_version}}" until="{{area_version}}"/>` in case of a normal run?

Fixes #141 
