### PR TITLE
Increase element-limit to avoid query out of memory

### DIFF
--- a/src/rules/areas.osm3s
+++ b/src/rules/areas.osm3s
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm-script timeout="86400" element-limit="1073741824">
+<osm-script timeout="86400" element-limit="2073741824">
 
 <union>
   <query type="relation">


### PR DESCRIPTION
This affects rambler.ru at the moment, i.e. only the first part of the rules file gets processed while the second half aborts with an error message due to an out of memory error.

Test case:

```C
way[craft][name]({{bbox}});out;map_to_area;out;
```
-> Number of ways != number of areas


New value for element-size is a bit arbitrarily chosen, maybe use 2147483648 (2^31) instead?

 Fixes https://github.com/drolbr/Overpass-API/issues/261