### PR TITLE
QL: node._ should only return nodes from inputset

### DIFF
--- a/src/overpass_api/frontend/map_ql_parser.cc
+++ b/src/overpass_api/frontend/map_ql_parser.cc
@@ -1413,7 +1413,17 @@ TStatement* parse_query(typename TStatement::Factory& stmt_factory,
 	error_output->add_parse_error("An empty query is not allowed", token.line_col().first);
     }
     else
-      statement = create_item_statement< TStatement >(stmt_factory, from, query_line_col.first);
+    {
+      if (type == "")
+        statement = create_item_statement< TStatement >(stmt_factory, from, query_line_col.first);
+      else
+      {
+        statement = create_query_statement< TStatement >
+           (stmt_factory, type, into, query_line_col.first);
+        TStatement* substatement = create_item_statement< TStatement >(stmt_factory, from, query_line_col.first);
+        statement->add_statement(substatement, "");
+      }
+    }
   }
   else if (clauses.size() == 1 && from == "")
   {


### PR DESCRIPTION
This way, QL gets the same semantics as the following XML variant:
```XML
  <query into="_" type="node">
    <item set="_"/>
  </query>
```
This also applies to way, rels, ...
Fixes #274