### PR TITLE
BASE_URL no longer defaults to main instance for /api/ping

### DIFF
--- a/src/cgi-bin/ping
+++ b/src/cgi-bin/ping
@@ -32,7 +32,9 @@ if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
 fi
 
 BIN_DIR="$EXEC_DIR/../bin"
-BASE_URL="http://overpass-api.de/api"
+
+# Set BASE_URL to your own server's external name
+BASE_URL="http://localhost/api"
 
 echo "Content-Type: text/html; charset=utf-8"
 echo


### PR DESCRIPTION
The current default already caused some issues a couple of times: people set up their own instance, activated monitoring only to create unnecessary load on the main instance, rather than monitoring their own server.

This patch assumes localhost as default.