### PR TITLE
Wait a bit more after fetching a non-existant yet diff.

### DIFF
--- a/src/bin/fetch_osc_and_apply.sh
+++ b/src/bin/fetch_osc_and_apply.sh
@@ -60,7 +60,7 @@ fetch_and_apply_minute_diff()
   printf -v TDIGIT2 %03u $(($ARG % 1000))
   ARG=$(($ARG / 1000))
   printf -v TDIGIT1 %03u $ARG
-  
+
   REMOTE_PATH="$DIFF_URL/$TDIGIT1/$TDIGIT2/$TDIGIT3"
   REMOTE_DIFF="$REMOTE_PATH.osc.gz"
   REMOTE_STATE="$REMOTE_PATH.state.txt"
@@ -81,7 +81,7 @@ fetch_and_apply_minute_diff()
   ret=$?
   rm $TMP_DIFF 2>/dev/null
   rm $TMP_DIFF_UNCOMPRESS 2>/dev/null
-  
+
   #Update the timestamp
   while [[ true ]];
   do
@@ -96,7 +96,7 @@ fetch_and_apply_minute_diff()
   	  cp $DB_DIR/osm_base_version $DB_DIR/osm_base_version_munin
   	  rm $TMP_STATE
   	  return $ret
-  	}; fi	
+  	}; fi
   done
 
 };
@@ -125,7 +125,7 @@ do
   else
   {
     REPLICATE_ID=$(($REPLICATE_ID - 1))
-    sleep 10 #Wait for the diff to be available
+    sleep 40 #Wait for the diff to be available
   }; fi
 };
 done


### PR DESCRIPTION
When applying diffs real time (database already up to date), the
minutely diff will only be available after a minute. So wait at least 40
secs instead of 10; less useless load on the replication server.