### PR TITLE
Make tests configurable, check lz4 configure options

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -274,6 +274,9 @@ EXTRA_DIST = \
   rules/areas.osm3s\
   rules/areas_delta.osm3s
 
-# Put test-bin here and test-bin/Makefile in configure.ac to activate test-bin
-SUBDIRS = test-bin
-#SUBDIRS =
+if COND_TESTS
+       MAYBE_TESTS = test-bin
+endif
+
+SUBDIRS = $(MAYBE_TESTS)
+

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -47,9 +47,13 @@ AC_FUNC_STRFTIME
 AC_CHECK_FUNCS([clock_gettime floor ftruncate getcwd munmap regcomp select shm_open socket sqrt strnlen])
 
 AC_ARG_ENABLE([lz4],
-              AS_HELP_STRING([--enable-lz4],[enable lz4 compression algorithm]),,
-              [enable_lz4="no"])
-AS_IF([test x"$enable_lz4" != "xno"], [want_lz4="yes"], [want_lz4="no"])
+     AS_HELP_STRING([--enable-lz4],[enable lz4 compression algorithm]),
+     [case "${enableval}" in
+       yes) enable_lz4=true ;;
+       no)  enable_lz4=false ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-lz4]) ;;
+     esac],[enable_lz4=false])
+AS_IF([test x$enable_lz4 != xfalse], [want_lz4="yes"], [want_lz4="no"])
 
 COMPRESS_LIBS="-lz"
 AC_SUBST(COMPRESS_LIBS, ["$COMPRESS_LIBS"])
@@ -73,8 +77,22 @@ fi
 
 AC_SUBST(COMPRESS_LIBS, ["$COMPRESS_LIBS"])
 
-AC_CONFIG_FILES([Makefile test-bin/Makefile])
-#AC_CONFIG_FILES([Makefile])
+AC_ARG_ENABLE([tests],
+     AS_HELP_STRING([--enable-tests],[enable Overpass API test suite]),
+     [case "${enableval}" in
+       yes) tests=true ;;
+       no)  tests=false ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-tests]) ;;
+     esac],[tests=false])
+
+AM_CONDITIONAL([COND_TESTS], [test x$tests = xtrue])
+
+AC_CONFIG_FILES([Makefile])
+
+if test "$tests" = "true"; then
+  AC_CONFIG_FILES([test-bin/Makefile])
+fi
+
 AC_OUTPUT
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
Add new configure option `--enable-tests` to make tests configurable. As most people don't want to compile tests, default is false.

There's some custom logic in:
* https://github.com/drolbr/Overpass-API/blob/master/osm-3s_testing/turn_testing_on.sh,
* https://github.com/drolbr/Overpass-API/blob/master/osm-3s_testing/make_dist.sh, and
* https://github.com/drolbr/Overpass-API/blob/master/src/test-bin/run_testsuite.sh#L31-L62

to tweak configure.ac and Makefile.am as needed.

As I don't see an immediate need for this anymore, I would just remove it and use `--enable-tests` configure option from now onwards.


