### PR TITLE
implement area size heuristic for area:id queries, fixes #359

### DIFF
--- a/src/overpass_api/statements/area_query.cc
+++ b/src/overpass_api/statements/area_query.cc
@@ -287,8 +287,20 @@ void Area_Query_Statement::get_ranges
 
 bool Area_Constraint::delivers_data(Resource_Manager& rman)
 {
+  int counter = 0;
+
   if (!area->areas_from_input())
-    return false;
+  {
+    Block_Backend< Uint31_Index, Area_Skeleton > area_locations_db
+        (rman.get_area_transaction()->data_index(area_settings().AREAS));
+    for (Block_Backend< Uint31_Index, Area_Skeleton >::Flat_Iterator
+        it(area_locations_db.flat_begin());
+        !(it == area_locations_db.flat_end()); ++it)
+    {
+      if (area->get_submitted_id() == it.object().id.val())
+        counter += it.object().used_indices.size();
+    }
+  }
   else
   {
     map< string, Set >::const_iterator mit = rman.sets().find(area->get_input());
@@ -305,8 +317,8 @@ bool Area_Constraint::delivers_data(Resource_Manager& rman)
         counter += it2->used_indices.size();
     }
   
-    return (counter <= 12);
   }
+  return (counter <= 12);
 }
 
 

--- a/src/overpass_api/statements/area_query.h
+++ b/src/overpass_api/statements/area_query.h
@@ -71,6 +71,7 @@ class Area_Query_Statement : public Output_Statement
        const Statement& query, Resource_Manager& rman);
 
     bool areas_from_input() const { return (submitted_id == 0); }
+    long long get_submitted_id() const { return submitted_id; }
     string get_input() const { return input; }
     
     static bool is_used() { return is_used_; }


### PR DESCRIPTION
The implementation feels a bit hacky, but I didn't see another way to access the area's `used_indices`. Any pointers for possible improvements are welcome.