### PR TITLE
Fix compilation error on Alpine Linux

### DIFF
--- a/src/template_db/types.cc
+++ b/src/template_db/types.cc
@@ -19,6 +19,7 @@
 
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <string.h>
 #include "types.h"
 
 


### PR DESCRIPTION
Just a small fix I had to implement when compiling Overpass on Alpine Linux.

<string.h> is needed for strcpy