### PR TITLE
[performance] Added FastCGI support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -169,7 +169,7 @@ bin_dispatcher_SOURCES = template_db/dispatcher.cc template_db/file_tools.cc tem
 bin_dispatcher_LDADD = libdispatcher.la libfrontend.la libsettings.la
 
 cgi_bin_interpreter_SOURCES = ${statements_cc} ${output_formats_cc} overpass_api/frontend/basic_formats.cc overpass_api/frontend/output_handler.cc overpass_api/dispatch/web_query.cc overpass_api/core/geometry.cc overpass_api/dispatch/scripting_core.cc overpass_api/dispatch/dispatcher_stub.cc template_db/types.cc overpass_api/frontend/map_ql_parser.cc overpass_api/frontend/tokenizer_utils.cc template_db/zlib_wrapper.cc template_db/lz4_wrapper.cc
-cgi_bin_interpreter_LDADD = libcore.la libdata.la @COMPRESS_LIBS@
+cgi_bin_interpreter_LDADD = libcore.la libdata.la @COMPRESS_LIBS@ @FASTCGI_LIBS@
 cgi_bin_timestamp_SOURCES = overpass_api/frontend/basic_formats.cc overpass_api/dispatch/db_timestamp.cc overpass_api/core/geometry.cc overpass_api/dispatch/dispatcher_stub.cc template_db/types.cc template_db/zlib_wrapper.cc template_db/lz4_wrapper.cc
 cgi_bin_timestamp_LDADD = libdispatcher.la libsettings.la libweboutput.la @COMPRESS_LIBS@
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -46,6 +46,8 @@ AC_FUNC_STAT
 AC_FUNC_STRFTIME
 AC_CHECK_FUNCS([clock_gettime floor ftruncate getcwd munmap regcomp select shm_open socket sqrt strnlen])
 
+
+
 AC_ARG_ENABLE([lz4],
               AS_HELP_STRING([--enable-lz4],[enable lz4 compression algorithm]),,
               [enable_lz4="no"])
@@ -72,6 +74,42 @@ if test "$want_lz4" != "no"; then
 fi
 
 AC_SUBST(COMPRESS_LIBS, ["$COMPRESS_LIBS"])
+
+# FastCGI
+
+AC_LANG_PUSH([C++])
+
+AC_ARG_ENABLE([fastcgi],
+     AS_HELP_STRING([--enable-fastcgi],[enable FastCGI]),
+     [case "${enableval}" in
+       yes) enable_fastcgi=true ;;
+       no)  enable_fastcgi=false ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-fastcgi]) ;;
+     esac],[enable_fastcgi=false])
+AS_IF([test x$enable_fastcgi != xfalse], [want_fastcgi="yes"], [want_fastcgi="no"])
+
+FASTCGI_LIBS=""
+
+if test "$want_fastcgi" != "no"; then
+  AC_CHECK_HEADER([fcgio.h], [
+    AC_CHECK_LIB(fcgi, FCGX_Accept_r, [
+      AC_DEFINE(HAVE_FASTCGI, 1, [Define if you have FastCGI library])
+      FASTCGI_LIBS="$FASTCGI_LIBS -lfcgi++ -lfcgi"
+    ], [
+      if test "$want_fastcgi" = "yes"; then
+	    AC_ERROR([Can't build with fastcgi support: libfcgi not found])
+      fi
+    ])
+  ], [
+    if test "$want_fastcgi" = "yes"; then
+      AC_ERROR([Can't build with FastCGI support: unable to find FastCGI header files])
+    fi
+  ])
+fi
+
+AC_SUBST(FASTCGI_LIBS, ["$FASTCGI_LIBS"])     
+AC_LANG_POP([C++])
+
 
 #AC_CONFIG_FILES([Makefile test-bin/Makefile])
 AC_CONFIG_FILES([Makefile])

--- a/src/overpass_api/data/collect_members.cc
+++ b/src/overpass_api/data/collect_members.cc
@@ -1011,6 +1011,14 @@ std::pair< std::map< Uint32_Index, std::vector< Node_Skeleton > >,
 const std::map< uint32, std::string >& relation_member_roles(Transaction& transaction)
 {
   static std::map< uint32, std::string > roles;
+  static std::string replicate_id;
+
+  // reset method level cache if replicate_id has changed
+  if (replicate_id != transaction.get_replicate_id())
+  {
+    roles.clear();
+    replicate_id = transaction.get_replicate_id();
+  }
 
   if (roles.empty())
   {

--- a/src/overpass_api/data/user_data_cache.h
+++ b/src/overpass_api/data/user_data_cache.h
@@ -31,18 +31,28 @@
 
 struct User_Data_Cache
 {
-  User_Data_Cache() : loaded(false) {}
+  User_Data_Cache()  {}
   const std::map< uint32, std::string >& users(Transaction& transaction);
-
-private:
-  std::map< uint32, std::string > users_;
-  bool loaded;
 };
 
 
 inline const std::map< uint32, std::string >& User_Data_Cache::users(
     Transaction& transaction)
 {
+  static std::map< uint32, std::string > users_;
+  static bool loaded;
+  static std::string replicate_id;
+
+  if (replicate_id != transaction.get_replicate_id())
+  {
+    replicate_id = transaction.get_replicate_id();
+    if (loaded)
+    {
+      users_.clear();
+      loaded = false;
+    }
+  }
+
   if (!loaded)
   {
     Block_Backend< Uint32_Index, User_Data > user_db

--- a/src/overpass_api/dispatch/dispatcher_stub.cc
+++ b/src/overpass_api/dispatch/dispatcher_stub.cc
@@ -127,10 +127,6 @@ Dispatcher_Stub::Dispatcher_Stub
       logger.annotated_log(out.str());
       throw;
     }
-    transaction = new Nonsynced_Transaction
-        (false, false, dispatcher_client->get_db_dir(), "");
-
-
 
     if (ic != nullptr)
       transaction = new Nonsynced_Transaction

--- a/src/overpass_api/dispatch/dispatcher_stub.h
+++ b/src/overpass_api/dispatch/dispatcher_stub.h
@@ -52,6 +52,11 @@ class Dispatcher_Stub : public Watchdog_Callback
 		    meta_modes meta_, int area_level,
 		    uint32 max_allowed_time, uint64 max_allowed_space, Parsed_Query& global_settings_);
     
+    Dispatcher_Stub(std::string db_dir_, Error_Output* error_output_, std::string xml_raw,
+                    meta_modes meta_, int area_level,
+                    uint32 max_allowed_time, uint64 max_allowed_space, Parsed_Query& global_settings_,
+                    Index_Cache* ic);
+
     // Called once per minute from the resource manager
     virtual void ping() const;
 

--- a/src/overpass_api/dispatch/scripting_core.cc
+++ b/src/overpass_api/dispatch/scripting_core.cc
@@ -181,6 +181,7 @@ bool parse_and_validate
         for (std::vector< Statement_Dump* >::iterator it = statement_stack< Statement_Dump >().begin();
             it != statement_stack< Statement_Dump >().end(); ++it)
           delete *it;
+        stmt_dump_factory_global = 0;
       }
       else
       {
@@ -196,12 +197,18 @@ bool parse_and_validate
     }
     catch(Parse_Error parse_error)
     {
+      stmt_factory_global = 0;
+      stmt_dump_factory_global = 0;
+
       if (error_output)
         error_output->add_parse_error(parse_error.message,
 				      xml_parser->current_line_number());
     }
     catch(File_Error e)
     {
+      stmt_factory_global = 0;
+      stmt_dump_factory_global = 0;
+
       std::ostringstream temp;
       temp<<"open: "<<e.error_number<<' '<<strerror(e.error_number)<<' '<<e.filename<<' '<<e.origin;
       if (error_output)
@@ -256,14 +263,6 @@ void initialize()
 {
   // initializes all static variables which are used throughout the application
   // this way, we can safely reuse the existing interpreter process via fastcgi
-  if (stmt_factory_global != NULL)
-    delete stmt_factory_global;
-
-  if (stmt_dump_factory_global != NULL)
-    delete stmt_dump_factory_global;
-
-  stmt_factory_global = 0;
-  stmt_dump_factory_global = 0;
   xml_parser = 0;
 
   statement_stack_.clear();

--- a/src/overpass_api/dispatch/scripting_core.h
+++ b/src/overpass_api/dispatch/scripting_core.h
@@ -54,4 +54,6 @@ meta_modes get_uses_meta_data();
 
 int determine_area_level(Error_Output* error_output, int area_level);
 
+void initialize();
+
 #endif

--- a/src/overpass_api/dispatch/web_query.cc
+++ b/src/overpass_api/dispatch/web_query.cc
@@ -106,7 +106,7 @@ int handle_request(const std::string & content, bool is_cgi, Index_Cache* ic)
       int area_level = determine_area_level(&error_output, 0);
       Dispatcher_Stub dispatcher("", &error_output, global_settings.get_input_params().find("data")->second,
 			         get_uses_meta_data(), area_level,
-				 max_allowed_time, max_allowed_space, global_settings);
+				 max_allowed_time, max_allowed_space, global_settings, ic);
       if (osm_script && osm_script->get_desired_timestamp())
         dispatcher.resource_manager().set_desired_timestamp(osm_script->get_desired_timestamp());
 

--- a/src/overpass_api/dispatch/web_query.cc
+++ b/src/overpass_api/dispatch/web_query.cc
@@ -242,7 +242,10 @@ int main(int argc, char *argv[])
   }
   else
   {
-    // Backup the stdio streambufs
+    int request_counter = 0;
+    time_t start_time = time(0);
+
+    // Backup the stdio streambuffers
     std::streambuf * cin_streambuf  = std::cin.rdbuf();
     std::streambuf * cout_streambuf = std::cout.rdbuf();
     std::streambuf * cerr_streambuf = std::cerr.rdbuf();
@@ -279,9 +282,16 @@ int main(int argc, char *argv[])
 
       int ret = handle_request(content, FCGX_IsCGI(), &ic);
 
+      // Restart process after error or a certain number of time / requests
+      time_t elapsed_time = time(NULL) - start_time;
+      if (ret < 0 || ++request_counter > 1000 || elapsed_time > 900)       //TODO: add configuration option
+      {
+        FCGX_Finish_r(&request);
+        break;
+      }
     }
 
-    // restore stdio streambufs
+    // restore stdio streambuffers
     std::cin.rdbuf(cin_streambuf);
     std::cout.rdbuf(cout_streambuf);
     std::cerr.rdbuf(cerr_streambuf);

--- a/src/overpass_api/frontend/user_interface.cc
+++ b/src/overpass_api/frontend/user_interface.cc
@@ -107,8 +107,8 @@ namespace
 }
 
 std::map< std::string, std::string > get_xml_cgi(
-    Error_Output* error_output, uint32 max_input_size,
-    Http_Methods& http_method, std::string& allow_header, bool& has_origin)
+    const std::string& content, Error_Output* error_output, uint32 max_input_size,
+    Http_Methods& http_method, std::string& allow_header, bool& has_origin, bool is_cgi)
 {
   // Check for various HTTP headers
   char* method = getenv("REQUEST_METHOD");
@@ -159,7 +159,7 @@ std::map< std::string, std::string > get_xml_cgi(
 	error_output->add_encoding_remark("Only whitespace found from GET method. Trying to retrieve input by POST method.");
     }
     
-    input = cgi_post_to_text();
+    input = (is_cgi ? cgi_post_to_text() : content);
     pos = 0;
     line_number = 1;
     while ((pos < input.size()) && (isspace(input[pos])))

--- a/src/overpass_api/frontend/user_interface.h
+++ b/src/overpass_api/frontend/user_interface.h
@@ -26,8 +26,8 @@
 
 
 std::map< std::string, std::string > get_xml_cgi(
-    Error_Output* error_output, uint32 max_input_size,
-    Http_Methods& http_method, std::string& allow_header, bool& has_origin);
+    const std::string& content, Error_Output* error_output, uint32 max_input_size,
+    Http_Methods& http_method, std::string& allow_header, bool& has_origin, bool is_cgi);
 
 std::string get_xml_console(Error_Output* error_output, uint32 max_input_size = 1048576);
 

--- a/src/overpass_api/statements/area_query.cc
+++ b/src/overpass_api/statements/area_query.cc
@@ -189,7 +189,7 @@ void Area_Constraint::filter(const Statement& query, Resource_Manager& rman, Set
 
 //-----------------------------------------------------------------------------
 
-bool Area_Query_Statement::is_used_ = false;
+int Area_Query_Statement::area_stmt_ref_counter_ = 0;
 
 Generic_Statement_Maker< Area_Query_Statement > Area_Query_Statement::statement_maker("area-query");
 
@@ -197,7 +197,7 @@ Area_Query_Statement::Area_Query_Statement
     (int line_number_, const std::map< std::string, std::string >& input_attributes, Parsed_Query& global_settings)
     : Output_Statement(line_number_)
 {
-  is_used_ = true;
+  ++area_stmt_ref_counter_;
 
   std::map< std::string, std::string > attributes;
 
@@ -223,6 +223,9 @@ Area_Query_Statement::Area_Query_Statement
 
 Area_Query_Statement::~Area_Query_Statement()
 {
+  if (area_stmt_ref_counter_ > 0)
+    --area_stmt_ref_counter_;
+
   for (std::vector< Query_Constraint* >::const_iterator it = constraints.begin();
       it != constraints.end(); ++it)
     delete *it;

--- a/src/overpass_api/statements/area_query.h
+++ b/src/overpass_api/statements/area_query.h
@@ -75,7 +75,7 @@ class Area_Query_Statement : public Output_Statement
     bool areas_from_input() const { return (submitted_id == 0); }
     std::string get_input() const { return input; }
 
-    static bool is_used() { return is_used_; }
+    static bool is_used() { return area_stmt_ref_counter_ > 0; }
 
     virtual std::string dump_xml(const std::string& indent) const
     {
@@ -102,7 +102,7 @@ class Area_Query_Statement : public Output_Statement
     std::string input;
     long long submitted_id;
     std::vector< Area_Skeleton::Id_Type > area_id;
-    static bool is_used_;
+    static int area_stmt_ref_counter_;
     std::vector< Query_Constraint* > constraints;
 };
 

--- a/src/overpass_api/statements/coord_query.cc
+++ b/src/overpass_api/statements/coord_query.cc
@@ -33,7 +33,7 @@
 #include "coord_query.h"
 
 
-bool Coord_Query_Statement::is_used_ = false;
+int Coord_Query_Statement::coord_stmt_ref_counter_ = 0;
 
 Generic_Statement_Maker< Coord_Query_Statement > Coord_Query_Statement::statement_maker("coord-query");
 
@@ -41,7 +41,7 @@ Coord_Query_Statement::Coord_Query_Statement
     (int line_number_, const std::map< std::string, std::string >& input_attributes, Parsed_Query& global_settings)
     : Output_Statement(line_number_)
 {
-  is_used_ = true;
+  ++coord_stmt_ref_counter_;
 
   std::map< std::string, std::string > attributes;
 

--- a/src/overpass_api/statements/coord_query.h
+++ b/src/overpass_api/statements/coord_query.h
@@ -33,7 +33,12 @@ class Coord_Query_Statement : public Output_Statement
                           Parsed_Query& global_settings);
     virtual std::string get_name() const { return "coord-query"; }
     virtual void execute(Resource_Manager& rman);
-    virtual ~Coord_Query_Statement() {}
+    virtual ~Coord_Query_Statement()
+    {
+      if (coord_stmt_ref_counter_ > 0)
+        --coord_stmt_ref_counter_;
+
+    }
     static Generic_Statement_Maker< Coord_Query_Statement > statement_maker;
 
     static int check_segment
@@ -51,7 +56,7 @@ class Coord_Query_Statement : public Output_Statement
     const static int TOGGLE_WEST = 4;
     const static int INTERSECT = 8;
 
-    static bool is_used() { return is_used_; }
+    static bool is_used() { return coord_stmt_ref_counter_ > 0; }
 
     virtual std::string dump_xml(const std::string& indent) const
     {
@@ -76,7 +81,7 @@ class Coord_Query_Statement : public Output_Statement
     std::string input;
     double lat, lon;
 
-    static bool is_used_;
+    static int coord_stmt_ref_counter_;
 };
 
 #endif

--- a/src/overpass_api/statements/id_query.cc
+++ b/src/overpass_api/statements/id_query.cc
@@ -27,7 +27,7 @@
 #include "id_query.h"
 
 
-bool Id_Query_Statement::area_query_exists_ = false;
+int Id_Query_Statement::area_query_ref_counter_ = 0;
 
 Generic_Statement_Maker< Id_Query_Statement > Id_Query_Statement::statement_maker("id-query");
 
@@ -282,7 +282,7 @@ Id_Query_Statement::Id_Query_Statement
   else if (attributes["type"] == "area")
   {
     type = Statement::AREA;
-    area_query_exists_ = true;
+    ++area_query_ref_counter_;
   }
   else
   {
@@ -412,6 +412,9 @@ Id_Query_Statement::~Id_Query_Statement()
   for (std::vector< Query_Constraint* >::const_iterator it = constraints.begin();
       it != constraints.end(); ++it)
     delete *it;
+
+  if (type == Statement::AREA && area_query_ref_counter_ > 0)
+     --area_query_ref_counter_;
 }
 
 Query_Constraint* Id_Query_Statement::get_query_constraint()

--- a/src/overpass_api/statements/id_query.h
+++ b/src/overpass_api/statements/id_query.h
@@ -42,7 +42,7 @@ class Id_Query_Statement : public Output_Statement
     Uint64 get_upper() const { return upper; }
     int get_type() const { return type; }
 
-    static bool area_query_exists() { return area_query_exists_; }
+    static bool area_query_exists() { return area_query_ref_counter_ > 0; }
 
     static std::string to_string(int type)
     {
@@ -83,7 +83,7 @@ class Id_Query_Statement : public Output_Statement
     Uint64 ref, lower, upper;
     std::vector< Query_Constraint* > constraints;
 
-    static bool area_query_exists_;
+    static int area_query_ref_counter_;
 };
 
 #endif

--- a/src/overpass_api/statements/make_area.cc
+++ b/src/overpass_api/statements/make_area.cc
@@ -35,7 +35,7 @@
 #include "print.h"
 
 
-bool Make_Area_Statement::is_used_ = false;
+int Make_Area_Statement::make_area_stmt_ref_counter_ = 0;
 
 Generic_Statement_Maker< Make_Area_Statement > Make_Area_Statement::statement_maker("make-area");
 
@@ -43,7 +43,7 @@ Make_Area_Statement::Make_Area_Statement
     (int line_number_, const std::map< std::string, std::string >& input_attributes, Parsed_Query& global_settings)
     : Output_Statement(line_number_)
 {
-  is_used_ = true;
+  ++make_area_stmt_ref_counter_;
 
   std::map< std::string, std::string > attributes;
 

--- a/src/overpass_api/statements/make_area.h
+++ b/src/overpass_api/statements/make_area.h
@@ -41,10 +41,13 @@ class Make_Area_Statement : public Output_Statement
                         Parsed_Query& global_settings);
     virtual std::string get_name() const { return "make-area"; }
     virtual void execute(Resource_Manager& rman);
-    virtual ~Make_Area_Statement() {}
+    virtual ~Make_Area_Statement() {
+      if (make_area_stmt_ref_counter_ > 0)
+        --make_area_stmt_ref_counter_;
+    }
     static Generic_Statement_Maker< Make_Area_Statement > statement_maker;
 
-    static bool is_used() { return is_used_; }
+    static bool is_used() { return make_area_stmt_ref_counter_ > 0; }
 
   private:
     std::string input, pivot;
@@ -59,7 +62,7 @@ class Make_Area_Statement : public Output_Statement
     static void add_segment_blocks
         (std::map< Uint31_Index, std::vector< Area_Block > >& areas, uint32 id);
 	
-    static bool is_used_;
+    static int make_area_stmt_ref_counter_;
 };
 
 #endif

--- a/src/overpass_api/statements/map_to_area.cc
+++ b/src/overpass_api/statements/map_to_area.cc
@@ -22,13 +22,13 @@
 
 Generic_Statement_Maker< Map_To_Area_Statement > Map_To_Area_Statement::statement_maker("map-to-area");
 
-bool Map_To_Area_Statement::is_used_ = false;
+int Map_To_Area_Statement::map_stmt_ref_counter_ = 0;
 
 Map_To_Area_Statement::Map_To_Area_Statement
     (int line_number_, const std::map< std::string, std::string >& input_attributes, Parsed_Query& global_settings)
     : Output_Statement(line_number_)
 {
-  is_used_ = true;
+  ++map_stmt_ref_counter_;
 
   std::map< std::string, std::string > attributes;
 

--- a/src/overpass_api/statements/map_to_area.h
+++ b/src/overpass_api/statements/map_to_area.h
@@ -32,15 +32,18 @@ class Map_To_Area_Statement : public Output_Statement
                           Parsed_Query& global_settings);
     virtual std::string get_name() const { return "map-to-area"; }
     virtual void execute(Resource_Manager& rman);
-    virtual ~Map_To_Area_Statement() {}
+    virtual ~Map_To_Area_Statement() {
+       if (map_stmt_ref_counter_  > 0)
+         --map_stmt_ref_counter_;
+    }
     static Generic_Statement_Maker< Map_To_Area_Statement > statement_maker;
 
-    static bool is_used() { return is_used_; }
+    static bool is_used() { return map_stmt_ref_counter_ > 0; }
 
   private:
     std::string input;
 
-    static bool is_used_;
+    static int map_stmt_ref_counter_;
 };
 
 #endif

--- a/src/overpass_api/statements/query.cc
+++ b/src/overpass_api/statements/query.cc
@@ -36,7 +36,7 @@
 
 //-----------------------------------------------------------------------------
 
-bool Query_Statement::area_query_exists_ = false;
+int Query_Statement::area_query_ref_counter_ = 0;
 
 Generic_Statement_Maker< Query_Statement > Query_Statement::statement_maker("query");
 
@@ -61,7 +61,7 @@ Query_Statement::Query_Statement
   else if (attributes["type"] == "area")
   {
     type = QUERY_AREA;
-    area_query_exists_ = true;
+    ++area_query_ref_counter_;
   }
   else
   {

--- a/src/overpass_api/statements/query.h
+++ b/src/overpass_api/statements/query.h
@@ -45,14 +45,17 @@ class Query_Statement : public Output_Statement
   public:
     Query_Statement(int line_number_, const std::map< std::string, std::string >& input_attributes,
                     Parsed_Query& global_settings);
-    virtual ~Query_Statement() {}
+    virtual ~Query_Statement() {
+      if (type == QUERY_AREA && area_query_ref_counter_ > 0)
+        --area_query_ref_counter_;
+    }
     virtual void add_statement(Statement* statement, std::string text);
     virtual std::string get_name() const { return "query"; }
     virtual void execute(Resource_Manager& rman);
 
     static Generic_Statement_Maker< Query_Statement > statement_maker;
 
-    static bool area_query_exists() { return area_query_exists_; }
+    static bool area_query_exists() { return area_query_ref_counter_ > 0; }
 
     static std::string to_string(int type)
     {
@@ -122,7 +125,7 @@ class Query_Statement : public Output_Statement
     std::vector< Statement* > substatements;
     Bbox_Query_Statement* global_bbox_statement;
 
-    static bool area_query_exists_;
+    static int area_query_ref_counter_;
 
     template< typename Skeleton, typename Id_Type >
     std::vector< std::pair< Id_Type, Uint31_Index > > collect_ids

--- a/src/template_db/transaction.h
+++ b/src/template_db/transaction.h
@@ -31,6 +31,18 @@ class Index_Cache
 
 public:
   Index_Cache() : replicate_id("") {};
+  ~Index_Cache() {
+
+    for (std::map< const File_Properties*, File_Blocks_Index_Base* >::iterator
+        it = data_files.begin(); it != data_files.end(); ++it)
+      delete it->second;
+    for (std::map< const File_Properties*, Random_File_Index* >::iterator
+        it = random_files.begin(); it != random_files.end(); ++it)
+      delete it->second;
+
+    data_files.clear();
+    random_files.clear();
+  }
 
 private:
   std::map< const File_Properties*, File_Blocks_Index_Base* >

--- a/src/template_db/transaction.h
+++ b/src/template_db/transaction.h
@@ -96,7 +96,7 @@ class Nonsynced_Transaction : public Transaction
 inline Nonsynced_Transaction::Nonsynced_Transaction
     (bool writeable_, bool use_shadow_,
      const std::string& db_dir_, const std::string& file_name_extension_)
-   : Nonsynced_Transaction(writeable_, use_shadow_, db_dir, file_name_extension, nullptr) {}
+   : Nonsynced_Transaction(writeable_, use_shadow_, db_dir_, file_name_extension_, nullptr) {}
 
 
 inline Nonsynced_Transaction::Nonsynced_Transaction


### PR DESCRIPTION
- Adds FastCGI support
- Adding new configure parameter `--enable-fastcgi` - new code is optional and as least invasive as possible.
- Resulting binary still supports both CGI and FastCGI
- Added a new Index Cache, which caches data_index & map_index across several queries. Once `replicate_id` changes, the cache is being discarded
- Other caches (like User_Data_Cache and relation_member_roles) are treated in a similar way and discarded upon `replicate_id` changes.

See https://github.com/drolbr/Overpass-API/issues/209 for more details on how to configure Apache / Nginx for FastCGI.

TODOs:

- [ ] Review coding
- [ ] Check if there's anything new in 0.7.54 which needs to be initialized as well after each query
- [ ] More testing!
- [ ] setrlimit needs to be changed to soft limits, otherwise `[maxelem: ...]` and `[timeout: ...]` cannot be set/updated across several queries
- [ ] Use of `std::lock_guard<std::mutex> guard(transaction_mutex);` is needed as preparation for #384, it's not really needed for FastCGI itself.


Thanks for reviewing!