### PR TITLE
Adding attic supprt to fetch_osc_and_apply.sh

### DIFF
--- a/.cvsignore
+++ b/.cvsignore
@@ -18,3 +18,5 @@ osmy_vigilance
 init_database.sql
 init_derived_data.sql
 
+/.idea/
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /cgi-bin/
 /test-bin/
 
+/.idea/
+*.iml

--- a/src/bin/apply_osc_to_db.sh
+++ b/src/bin/apply_osc_to_db.sh
@@ -48,7 +48,7 @@ elif [[ $3 == "--meta=no" ]]; then
   META=
 else
 {
-  echo "You must specify --meta=yes or --meta=no"
+  echo "You have to specify --meta=yes, --meta=no or --meta=attic"
   exit 0
 }; fi
 

--- a/src/bin/fetch_osc_and_apply.sh
+++ b/src/bin/fetch_osc_and_apply.sh
@@ -107,6 +107,10 @@ META_OPTION=
 if [[ $2 == "--meta=yes" ]]; then
 {
   META_OPTION="--meta"
+};
+elif [[ $2 == "--meta=attic" ]]; then
+{
+  META_OPTION="--keep-attic"
 }; fi
 
 


### PR DESCRIPTION
With these changes, the script `fetch_osc_and_apply.sh` could also started with parameter `--meta=attic` like usage of `apply_osc_to_db.sh`