### PR TITLE
OSM_Element_Metadata doesn't initialize its variables

### DIFF
--- a/src/overpass_api/core/datatypes.h
+++ b/src/overpass_api/core/datatypes.h
@@ -447,7 +447,7 @@ struct User_Data
 
 struct OSM_Element_Metadata
 {
-  OSM_Element_Metadata() : user_id(0) {}
+  OSM_Element_Metadata() : user_id(0), changeset(0) {}
 
   uint32 version;
   uint64 timestamp;


### PR DESCRIPTION
Recently I've switched my minute diffs from http://download.openstreetmap.fr/replication/ to http://download.geofabrik.de/europe/.

And while openstreetmap.fr provides all the metadata information, Geofabrik provides only version information (and no values for attributes like `changeset`, `user`, `uid`). Using such diffs for update_database results in database "corruption", as random values land in `changeset`.

As I've checked source code [node_start](https://github.com/drolbr/Overpass-API/blob/master/src/overpass_api/osm-backend/osm_updater.cc#L137), [way_start](https://github.com/drolbr/Overpass-API/blob/master/src/overpass_api/osm-backend/osm_updater.cc#L198) and [relation_start](https://github.com/drolbr/Overpass-API/blob/master/src/overpass_api/osm-backend/osm_updater.cc#L282) they create OSM_Element_Metadata object but `changeset`, `user_id` and `user_name` fields are not set if not provided in source. [Object constructor](https://github.com/drolbr/Overpass-API/blob/master/src/overpass_api/core/datatypes.h#L448) does not initialize `changeset` (and I guess that constructor depends on implicit empty string initialization for `user_name`), though `user_id` is.

Looks like following change fixes problem.

Though looking around the code, it might be needed to initialize more variables (`timestamp`, `version`), but I do not know, how this might affect performance.