### PR TITLE
Link to blog on dev instance

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -11,7 +11,7 @@
 
 <div style="clear:left; min-height:6em; font-family:sans-serif; text-align:center; margin-bottom:0.5em">
 <div style="height:6em; width:15%; margin-right:1%; color:navy; float:left"><h2>Use</h2></div>
-<div style="height:6em; width:20%; background-color:navy; margin-right:1%; float:left"><a href="blog/" style="color:white; text-decoration:none;">&nbsp;<br/>Blog</a></div>
+<div style="height:6em; width:20%; background-color:navy; margin-right:1%; float:left"><a href="https://dev.overpass-api.de/blog/" style="color:white; text-decoration:none;">&nbsp;<br/>Blog</a></div>
 <div style="height:6em; width:20%; background-color:#aaaacc; color:white; margin-right:1%; float:left">&nbsp;<br/>POIs showing Maps</div>
 <div style="height:6em; width:20%; background-color:navy; margin-right:1%; float:left"><a href="public_transport.html" style="color:white; text-decoration:none;">&nbsp;<br/>Public Transport Diagrams</a></div>
 <div style="height:6em; width:20%; background-color:navy; margin-right:1%; float:left"><a href="https://wiki.openstreetmap.org/Overpass_API/Permanent_ID" style="color:white; text-decoration:none;">&nbsp;<br/>Permanent OSM ID</a></div>


### PR DESCRIPTION
Only the dev instance has the blog. The blog link at http://overpass-api.de/ doesn't work.