### PR TITLE
Add power=plant to area creation rules

### DIFF
--- a/src/rules/areas.osm3s
+++ b/src/rules/areas.osm3s
@@ -168,6 +168,11 @@
     <has-kv k="area" v="no" modv="not"/>
   </query>
   <query type="way">
+    <has-kv k="power" v="plant"/>
+    <has-kv k="name"/>
+    <has-kv k="area" v="no" modv="not"/>
+  </query>
+  <query type="way">
     <has-kv k="power" v="generator"/>
     <has-kv k="name"/>
     <has-kv k="area" v="no" modv="not"/>


### PR DESCRIPTION
Replicated rule for e.g. power=generator.

Resolves #609

From issue:

> Posting an issue as instructed by https://wiki.openstreetmap.org/wiki/Overpass_API/Areas. My use case involves querying for objects within the area of a power plant way.

> The area creation rules as specified here include power=station, power=generator, power=sub_station and power=transformer but no power=plant. Most power plants have landuse=industrial but it if the plant is left without a name, no area is created. It also seems that the landuse=industrial tag may be disputed for power plants.

