### PR TITLE
Fix inconsistent geometry calculation of partial relations

### DIFF
--- a/src/overpass_api/data/relation_geometry_store.cc
+++ b/src/overpass_api/data/relation_geometry_store.cc
@@ -175,7 +175,9 @@ std::vector< std::vector< Quad_Coord > > Relation_Geometry_Store::get_geometry
     if (it->type == Relation_Entry::NODE)
     {
       const Node* node = binary_search_for_id(nodes, it->ref);
-      if (node == 0 || !matches_bbox(node->index, node->ll_lower_))
+      if (node == 0)
+        result.push_back(std::vector< Quad_Coord >());
+      else if (!matches_bbox(node->index, node->ll_lower_))
         result.push_back(std::vector< Quad_Coord >(1, Quad_Coord(0u, 0u)));
       else
         result.push_back(std::vector< Quad_Coord >(1, Quad_Coord(node->index, node->ll_lower_)));


### PR DESCRIPTION
When the API is used with a database which was generated from a extracted OSM file, the bounding box of relations is calculated inconsistently. If the relation contains missing ways, the bounding box is not affected by them. However, if the relation contains a missing node, an artificial `Quad_Coord(0u, 0u)` gets inserted.

Before: ```<bounds minlat="-91.0000000" minlon="-214.7483648"
maxlat="45.9167004" maxlon="7.8759229"/>```  
After: ```<bounds minlat="45.8197974" minlon="7.8613734" maxlat="45.9167004"
maxlon="7.8759229"/>```