### PR TITLE
Fix typo in to_string(int type)

### DIFF
--- a/src/overpass_api/statements/query.h
+++ b/src/overpass_api/statements/query.h
@@ -100,7 +100,7 @@ class Query_Statement : public Output_Statement
       else if (type == (QUERY_NODE | QUERY_WAY | QUERY_RELATION))
         return "nwr";
       else if (type == (QUERY_NODE | QUERY_WAY))
-        return "nwr";
+        return "nw";
       else if (type == (QUERY_WAY | QUERY_RELATION))
         return "wr";
       else if (type == (QUERY_NODE | QUERY_RELATION))


### PR DESCRIPTION
@mmd-osm commented on [Apr 16, 2020](https://github.com/drolbr/Overpass-API/issues/535#issuecomment-614564521):

> Yes, https://github.com/drolbr/Overpass-API/blob/oversized_backend_objects/src/overpass_api/statements/query.h#L103 is incorrect. Care to create a new issue for it?
> You shouldn't notice this when running a query, that method is only called when converting queries between different formats: