### PR TITLE
define off64_t ifdef NATIVE_LARGE_FILES

### DIFF
--- a/src/template_db/types.h
+++ b/src/template_db/types.h
@@ -33,6 +33,7 @@
 #define ftruncate64 ftruncate
 #define lseek64 lseek
 #define open64 open
+#define off64_t off_t
 #endif
 
 


### PR DESCRIPTION
Addition just below the definitions of ftruncate64, lseek64 and open64 enclosed in the existing condition. off64_t was added a decade later, which explains the previous omission and makes it easy to miss. On a related note, the condition could be revised to accommodate other compilers.