### PR TITLE
Potential issue with working directory in the `rules_loop.sh`

### DIFF
--- a/src/bin/rules_loop.sh
+++ b/src/bin/rules_loop.sh
@@ -22,7 +22,7 @@ if [[ -z $1  ]]; then
   exit 0
 fi
 
-DB_DIR="$(pwd)/$1"
+DB_DIR=$1
 
 EXEC_DIR="$(dirname $0)/"
 if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then


### PR DESCRIPTION
This doesn't need to be the final outcome, but when I was going through the [guide](https://wiki.openstreetmap.org/wiki/Overpass_API/Installation#Area_creation), I couldn't figure out for the life of me why areas wasn't working. Turns out that the way this script is set up means that I had to execute the script from a working directory of `/` in order for the pwd in the deleted changes to work.

I think we can also pretty it up a bit (I'm not sure why we exactly need to sanitize the $EXEC_DIR as a relative of our invoking directory, I think there is a bug here if we executed without absolute.

I think we can simplify the two down to just forgetting about relative execution, since the guides from osm wiki tells us to execute via the absolute path (`nohup $EXEC_DIR/bin/rules_loop.sh $DB_DIR &`, where the two env vars are stored as abolutes)