### PR TITLE
Return status code 500 (instead of 200) when there's a run time error

### DIFF
--- a/src/overpass_api/frontend/web_output.cc
+++ b/src/overpass_api/frontend/web_output.cc
@@ -102,7 +102,7 @@ void Web_Output::runtime_error(const std::string& error)
   {
     std::ostringstream out;
     out<<"runtime error: "<<error;
-    display_error(out.str(), 200);
+    display_error(out.str(), 500);
   }
 }
 


### PR DESCRIPTION
HTTP 200 is for when there is no problem.

In my experience, if something happens to an overpass server, you can get `runtime error: open64: 2 No such file or directory /ssd/overpass-database//osm3s_v0.7.58_osm_base Unix_Socket::7`. However when this happens the HTTP status code is 200. With this patch, the HTTP status code will be 500.

This allows the existance, or occurance, of this error to be detected, logged, with potential automatic failover happening.