### PR TITLE
Darwin: alias off64_t to off_t in NATIVE_LARGE_FILES block

### DIFF
--- a/src/template_db/types.h
+++ b/src/template_db/types.h
@@ -33,6 +33,7 @@
 #define ftruncate64 ftruncate
 #define lseek64 lseek
 #define open64 open
+typedef off_t off64_t;
 #endif
 
 


### PR DESCRIPTION
The existing `#ifdef NATIVE_LARGE_FILES` block in `src/template_db/types.h` aliases `ftruncate64`, `lseek64`, and `open64` so osm-3s can build against platforms without glibc's `*64` symbols (notably macOS).

The `off64_t` *type* is still referenced — by `Raw_File::size`, `Raw_File::resize`, `Raw_File::seek` — so the block alone isn't sufficient on Darwin. Apple clang fails with:

```
error: unknown type name 'off64_t'; did you mean 'off_t'?
```

Adding `typedef off_t off64_t;` to the same guarded block finishes the job. `off_t` is 64-bit on all 64-bit Darwin targets, so this is semantically identical to the symbols the block already aliases.

Activate via `CPPFLAGS="-DNATIVE_LARGE_FILES"` at `configure` time (unchanged).

Two companion PRs address other Darwin-specific issues I hit while running Overpass natively on Apple Silicon — separate so they can be reviewed independently: #789 (sun_len fix), #790 (Mmap → pread).