### PR TITLE
Replace per-block Mmap with pread, ~300x apply speedup on Darwin

### DIFF
--- a/src/template_db/file_blocks.h
+++ b/src/template_db/file_blocks.h
@@ -787,25 +787,56 @@ typename File_Blocks< TIndex, TIterator >::Write_Iterator
 class Mmap
 {
 public:
+  // Backed by pread into a heap buffer rather than mmap+munmap. Each
+  // compressed block is read once, decompressed into a separate buffer,
+  // and never revisited -- the memory mapping provides no reuse benefit.
+  //
+  // On macOS every mmap syscall takes ~0.25 ms of kernel overhead
+  // (virtual-range allocation, page-table setup, fault-in, teardown on
+  // munmap). File_Blocks::read_block_ creates one Mmap per compressed
+  // block; across thousands of block reads per minute-diff that
+  // overhead dominates wall time -- profiling showed 97% of
+  // update_from_dir's on-CPU samples inside __mmap.
+  //
+  // Replacing with pread keeps ptr() pointer-compatible with every
+  // callsite (Zlib/LZ4 Inflate) and is no slower on Linux, where pread
+  // hits the same page cache that mmap would have.
   Mmap(int fd, off_t offset, size_t length_, const std::string& file_name, const std::string& origin)
-      : addr(0), length(length_)
+      : buffer(0), length(length_)
   {
     if (length > 0)
-      addr = mmap(0, length, PROT_READ, MAP_PRIVATE, fd, offset);
-    if (addr == (void*)(-1))
-      throw File_Error(errno, file_name, origin);
-    posix_madvise(addr, length, POSIX_MADV_WILLNEED);
+    {
+      buffer = new uint8_t[length];
+      size_t got = 0;
+      while (got < length)
+      {
+        ssize_t n = pread(fd, buffer + got, length - got, offset + got);
+        if (n < 0)
+        {
+          int err = errno;
+          delete[] buffer;
+          buffer = 0;
+          throw File_Error(err, file_name, origin);
+        }
+        if (n == 0)
+        {
+          delete[] buffer;
+          buffer = 0;
+          throw File_Error(0, file_name, origin);
+        }
+        got += (size_t)n;
+      }
+    }
   }
   ~Mmap()
-  { 
-    if (addr)
-      munmap(addr, length);
+  {
+    delete[] buffer;
   }
-  
-  uint64* ptr() { return (uint64*)addr; }
-  
+
+  uint64* ptr() { return (uint64*)buffer; }
+
 private:
-  void* addr;
+  uint8_t* buffer;
   size_t length;
 };
 


### PR DESCRIPTION
Profiling `update_from_dir` with macOS `sample(1)` for 30 seconds on an Apple Silicon M-series showed **350 of 361 on-CPU samples (97%) inside the `__mmap` syscall**. The hot path is:

```
File_Blocks::read_block_ -> Mmap::Mmap -> mmap
```

called once per compressed block read. On macOS each `mmap` syscall costs ~0.25 ms of kernel overhead (virtual range alloc, page-table setup, fault-in, teardown on `munmap`). Across thousands of block reads per minute-diff the syscall tax dominates wall time and prevents apply from keeping pace with the 1-diff-per-minute fetch rate. Linux mmap is cheaper so this is invisible on Linux.

## Analysis

For Overpass's access pattern there's no benefit to a memory mapping: each compressed block is read once, decompressed into a separate buffer by Zlib/LZ4 Inflate, and never revisited. The `Mmap` class exists only to own the read buffer for decompression. Replacing the `mmap`/`munmap` pair with a `pread` into a heap buffer keeps `Mmap::ptr()` pointer-compatible with every caller and eliminates the syscall tax. Linux performance is unaffected — `pread` hits the same page cache that `mmap` would have.

## Measured effect

Single-diff apply (diff 7076518, 6550 ops) against a live 291 GB database on Apple Silicon:

| | wall time | CPU% | notes |
|---|---|---|---|
| before | 9 min 01 s | 100% | 97% samples in `__mmap` |
| after | 1.79 s | 67% | now compute-bound |

~300x speedup. The `NO_COMPRESSION` branch of `File_Blocks::read_block_` already uses `pread` via `data_file.read()`; this brings the compressed path to parity.

## Notes

- Public interface (`Mmap::ptr()`) unchanged — no caller needs adjusting.
- Exception behavior preserved: throws `File_Error` on I/O failure with the same arguments.
- No Linux regression expected (pread and mmap both use the unified page cache), but would welcome Linux benchmarks from a reviewer with access.

Companion PRs #788 (off64_t alias) and #789 (sun_len fix) address other Darwin-specific issues hit while bringing osm-3s up on Apple Silicon natively.