### PR TITLE
Fix typo in osm_mem_status

### DIFF
--- a/src/munin/osm_mem_status
+++ b/src/munin/osm_mem_status
@@ -10,6 +10,6 @@ if [[ "$1" = "config" ]]; then
   exit 0
 }; fi
 
-GRANTED=`$(/OVERPASS_EXEC_DIR/bin/dispatcher --osm-base --status | grep -E "^Average claimed space:" | awk '{ print $4; }')
+GRANTED=$(/OVERPASS_EXEC_DIR/bin/dispatcher --osm-base --status | grep -E "^Average claimed space:" | awk '{ print $4; }')
 
 echo "osm_mem_status.value $GRANTED"


### PR DESCRIPTION
See https://community.openstreetmap.org/t/overpass-api-performance-issues/140598/146

I've fixed this on the production servers and the statistics for granted memory are now displayed in Munin. Needs to be made permanent.