### PR TITLE
Decoding, validation, and path-resolution fixes for cgi-bin scripts

### DIFF
--- a/src/cgi-bin/augmented_diff
+++ b/src/cgi-bin/augmented_diff
@@ -20,27 +20,62 @@
 
 ID=0
 BBOX=
-INFO=
 DEBUG=
-EXECBASE="`dirname $0`/../"
+EXECBASE="$(realpath "$(dirname "$0")/..")"
 CACHE_DIR="/tmp/osm3s_augmented_diffs_cache/"
+NUMBER_RE='-?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][+-]?[0-9]+)?'
+WS='[[:space:]]*'
+BBOX_RE="^${WS}${NUMBER_RE}${WS},${WS}${NUMBER_RE}${WS},${WS}${NUMBER_RE}${WS},${WS}${NUMBER_RE}${WS}\$"
+ID_RE='^(0|[1-9][0-9]{0,11})$'
 
+bad_request()
+{
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo "Status: 400 Bad Request"
+  echo
+  echo "$1"
+  exit 0
+}
+
+set -f
 IFS=$'&'
 for KEY_VAL in $QUERY_STRING; do
 {
-  if [[ ${KEY_VAL:0:3} == "id=" ]]; then
-    ID="${KEY_VAL:3}"
-  elif [[ ${KEY_VAL:0:5} == "bbox=" && ${KEY_VAL:0:9} != "bbox=-180" ]]; then
-    BBOX=`echo "${KEY_VAL:5}" | $EXECBASE/bin/uncgi`
-  elif [[ ${KEY_VAL:0:6} == "debug=" ]]; then
-    DEBUG=`echo "${KEY_VAL:6}" | $EXECBASE/bin/uncgi`
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
   fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$EXECBASE"/bin/uncgi) || bad_request "Malformed query string"
+  VAL=$(printf '%s' "$RAW_VAL" | "$EXECBASE"/bin/uncgi) || bad_request "Malformed query string"
+  case "$KEY" in
+    id)
+      if [[ $VAL =~ $ID_RE ]]; then
+        ID="$VAL"
+      else
+        bad_request "Invalid id parameter"
+      fi
+      ;;
+    bbox)
+      if [[ $VAL =~ $BBOX_RE ]]; then
+        if [[ ${VAL:0:4} != "-180" ]]; then
+          BBOX="$VAL"
+        fi
+      else
+        bad_request "Invalid bbox parameter"
+      fi
+      ;;
+    debug)
+      DEBUG="$VAL"
+      ;;
+  esac
 }; done
 unset IFS
+set +f
 
-EPOCHSECS=$(($ID * 60 + 1347432900))
-SINCE=`date --utc --date="@$EPOCHSECS" '+%FT%H:%M:%SZ'`
-UNTIL=`date --utc --date="@$(($EPOCHSECS + 60))" '+%FT%H:%M:%SZ'`
+EPOCHSECS=$((ID * 60 + 1347432900))
+SINCE=$(date --utc --date="@$EPOCHSECS" '+%FT%H:%M:%SZ')
+UNTIL=$(date --utc --date="@$((EPOCHSECS + 60))" '+%FT%H:%M:%SZ')
 
 if [[ -z $BBOX ]]; then
 
@@ -64,5 +99,5 @@ if [[ -z $DEBUG ]]; then
 else
   echo "Content-Type: text/plain"
   echo
-  echo $QUERY_STRING
+  echo "$QUERY_STRING"
 fi

--- a/src/cgi-bin/augmented_diff
+++ b/src/cgi-bin/augmented_diff
@@ -21,7 +21,8 @@
 ID=0
 BBOX=
 DEBUG=
-EXECBASE="$(realpath "$(dirname "$0")/..")"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 CACHE_DIR="/tmp/osm3s_augmented_diffs_cache/"
 NUMBER_RE='-?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][+-]?[0-9]+)?'
 WS='[[:space:]]*'
@@ -46,8 +47,8 @@ for KEY_VAL in $QUERY_STRING; do
   else
     RAW_VAL=
   fi
-  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$EXECBASE"/bin/uncgi) || bad_request "Malformed query string"
-  VAL=$(printf '%s' "$RAW_VAL" | "$EXECBASE"/bin/uncgi) || bad_request "Malformed query string"
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
   case "$KEY" in
     id)
       if [[ $VAL =~ $ID_RE ]]; then
@@ -95,7 +96,7 @@ fi
 #REQUEST_METHOD=GET
 
 if [[ -z $DEBUG ]]; then
-  ./interpreter
+  "$EXEC_DIR"/interpreter
 else
   echo "Content-Type: text/plain"
   echo

--- a/src/cgi-bin/augmented_diff_status
+++ b/src/cgi-bin/augmented_diff_status
@@ -19,32 +19,58 @@
 
 
 CACHE_DIR="/tmp/osm3s_augmented_diffs_cache/"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+TIMESTAMP_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
+WS='[[:space:]]*'
+TOKEN='[!#$%&'"'"'*+.^_`|~[:alnum:]-]+'
+HEADERS_RE="^${WS}${TOKEN}(${WS},${WS}${TOKEN})*${WS}\$"
 
+print_cors_headers()
+{
+  if [[ -n $HTTP_ACCESS_CONTROL_REQUEST_HEADERS && $HTTP_ACCESS_CONTROL_REQUEST_HEADERS =~ $HEADERS_RE ]]; then
+    echo "Access-Control-Allow-Headers: $HTTP_ACCESS_CONTROL_REQUEST_HEADERS"
+  fi
+  if [[ -n $HTTP_ORIGIN ]]; then
+    echo "Access-Control-Allow-Origin: *"
+  fi
+}
 
-# Do HTTP headers with respect to CORS
-echo "Content-Type: text/plain; charset=utf-8"
-if [[ -n $HTTP_ACCESS_CONTROL_REQUEST_HEADERS ]]; then
-  echo "Access-Control-Allow-Headers: $HTTP_ACCESS_CONTROL_REQUEST_HEADERS"
-fi
-if [[ -n $HTTP_ORIGIN ]]; then
-  echo "Access-Control-Allow-Origin: *"
-fi
-if [[ $REQUEST_METHOD == "OPTIONS" ]]; then {
+internal_error()
+{
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo "Status: 500 Internal Server Error"
+  print_cors_headers
+  echo
+  echo "$1"
+  exit 0
+}
+
+if [[ $REQUEST_METHOD == "OPTIONS" ]]; then
+  echo "Content-Type: text/plain; charset=utf-8"
+  print_cors_headers
   echo "Access-Control-Allow-Methods: GET, POST, OPTIONS"
   echo "Content-Length: 0"
   echo
   exit 0
-}; fi
-echo
+fi
 
 if [[ -r "$CACHE_DIR/newest" ]]; then
+  echo "Content-Type: text/plain; charset=utf-8"
+  print_cors_headers
+  echo
   cat "$CACHE_DIR/newest"
   exit 0
 fi
 
-TIMESTAMP=`./timestamp | tail -n 1`
+TIMESTAMP=$("$EXEC_DIR"/timestamp | tail -n 1)
 
-if [[ ${TIMESTAMP:0:1} == "2" ]]; then
-  EPOCHSECS=`date --date=$TIMESTAMP '+%s'`
-  echo $(( ( $EPOCHSECS - 1347432960 ) / 60 ))
+if [[ ! $TIMESTAMP =~ $TIMESTAMP_RE ]]; then
+  internal_error "Invalid timestamp from backend"
 fi
+
+EPOCHSECS=$(date --date="$TIMESTAMP" '+%s')
+
+echo "Content-Type: text/plain; charset=utf-8"
+print_cors_headers
+echo
+echo $(( ( EPOCHSECS - 1347432960 ) / 60 ))

--- a/src/cgi-bin/augmented_map
+++ b/src/cgi-bin/augmented_map
@@ -17,29 +17,58 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PT_Diagrams.  If not, see <http://www.gnu.org/licenses/>.
 
-BUF="$QUERY_STRING&"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
 ID=
 LAT=50.7421
 LON=7.0624
 ZOOM=6
 
+NUMBER_RE='-?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][+-]?[0-9]+)?'
+ID_RE='^(0|[1-9][0-9]{0,11})$'
+LAT_RE="^${NUMBER_RE}\$"
+LON_RE="^${NUMBER_RE}\$"
+ZOOM_RE='^[0-9]{1,2}$'
+
+set -f
 IFS=$'&'
 for KEY_VAL in $QUERY_STRING; do
 {
-  if [[ ${KEY_VAL:0:3} == "id=" ]]; then
-    ID="${KEY_VAL:3}"
-  elif [[ ${KEY_VAL:0:4} == "lat=" ]]; then
-    LAT="${KEY_VAL:4}"
-  elif [[ ${KEY_VAL:0:4} == "lon=" ]]; then
-    LON="${KEY_VAL:4}"
-  elif [[ ${KEY_VAL:0:5} == "zoom=" ]]; then
-    ZOOM="${KEY_VAL:5}"
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
   fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || continue
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || continue
+  case "$KEY" in
+    id)
+      [[ $VAL =~ $ID_RE ]] && ID="$VAL"
+      ;;
+    lat)
+      [[ $VAL =~ $LAT_RE ]] && LAT="$VAL"
+      ;;
+    lon)
+      [[ $VAL =~ $LON_RE ]] && LON="$VAL"
+      ;;
+    zoom)
+      [[ $VAL =~ $ZOOM_RE ]] && ZOOM="$VAL"
+      ;;
+  esac
 }; done
 unset IFS
+set +f
 
 echo "Content-Type: text/html; charset=utf-8"
 echo
 
-cat </var/www/augmented_diffs.html | awk "{ i=index(\$0,\"\$ID\"); if (i==0) { i=index(\$0,\"\$LAT\"); if (i==0) { i=index(\$0,\"\$LON\"); if (i==0) { i=index(\$0,\"\$ZOOM\"); if (i==0) { print \$0; } else { print substr(\$0,1,i-1) \"$ZOOM\" substr(\$0,i+5); } } else { print substr(\$0,1,i-1) \"$LON\" substr(\$0,i+4); } } else { print substr(\$0,1,i-1) \"$LAT\" substr(\$0,i+4); } } else { print substr(\$0,1,i-1) \"$ID\" substr(\$0,i+3); }; }"
+awk -v id="$ID" -v lat="$LAT" -v lon="$LON" -v zoom="$ZOOM" '
+{
+  line = $0
+  sub(/\$ID/, id, line)
+  sub(/\$LAT/, lat, line)
+  sub(/\$LON/, lon, line)
+  sub(/\$ZOOM/, zoom, line)
+  print line
+}' /var/www/augmented_diffs.html

--- a/src/cgi-bin/augmented_state_by_date
+++ b/src/cgi-bin/augmented_state_by_date
@@ -17,75 +17,120 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-BUF="$QUERY_STRING&"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
+LOCAL_DIR="/var/www/augmented_diffs"
 
-STATE=
-EXECBASE="`dirname $0`/../"
-BIN_DIR="${EXECBASE}bin"
+TIME_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
+INTEGER_RE='^(0|[1-9][0-9]*)$'
+WS='[[:space:]]*'
+TOKEN='[!#$%&'"'"'*+.^_`|~[:alnum:]-]+'
+HEADERS_RE="^${WS}${TOKEN}(${WS},${WS}${TOKEN})*${WS}\$"
 
-IFS=$'&'
-for KEY_VAL in $QUERY_STRING; do
+print_cors_headers()
 {
-  if [[ ${KEY_VAL:0:9} == "osm_base=" ]]; then
-    STATE="${KEY_VAL:9}"
+  if [[ -n $HTTP_ACCESS_CONTROL_REQUEST_HEADERS && $HTTP_ACCESS_CONTROL_REQUEST_HEADERS =~ $HEADERS_RE ]]; then
+    echo "Access-Control-Allow-Headers: $HTTP_ACCESS_CONTROL_REQUEST_HEADERS"
   fi
-}; done
-unset IFS
+  if [[ -n $HTTP_ORIGIN ]]; then
+    echo "Access-Control-Allow-Origin: *"
+  fi
+}
 
-
-TARGET_TIME="`echo "$STATE" | $BIN_DIR/uncgi`"
-LOWER="0"
-UPPER="`cat /var/www/augmented_diffs/state.txt`"
-LOCAL_DIR="/var/www/augmented_diffs/"
-
-get_replicate_filename()
+bad_request()
 {
-  printf -v TDIGIT3 %03u $(($TARGET % 1000))
-  ARG=$(($TARGET / 1000))
-  printf -v TDIGIT2 %03u $(($ARG % 1000))
-  ARG=$(($ARG / 1000))
-  printf -v TDIGIT1 %03u $ARG
-  LOCAL_PATH="$LOCAL_DIR/$TDIGIT1/$TDIGIT2"
-  REPLICATE_FILENAME="$LOCAL_PATH/$TDIGIT3"
-};
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo "Status: 400 Bad Request"
+  print_cors_headers
+  echo
+  echo "$1"
+  exit 0
+}
 
-update_state()
+internal_error()
 {
-  get_replicate_filename
-  if [[ -s "$REPLICATE_FILENAME.state.txt" ]]; then {
-    TIMESTAMP_LINE=`cat "$REPLICATE_FILENAME.state.txt"`
-    DATA_VERSION=${TIMESTAMP_LINE:9}
-  }; fi
-};
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo "Status: 500 Internal Server Error"
+  print_cors_headers
+  echo
+  echo "$1"
+  exit 0
+}
 
-while [[ $(($LOWER + 1)) -lt $UPPER ]]; do
-{
-  TARGET=$((($LOWER + $UPPER) / 2))
-  update_state
-  #echo "$TARGET - $TIMESTAMP_LINE"
-  if [[ -s "$REPLICATE_FILENAME.state.txt" && "$DATA_VERSION" < "$TARGET_TIME" ]]; then
-  {
-    LOWER=$TARGET
-  }; else
-  {
-    UPPER=$TARGET
-  }; fi
-}; done
-
-# Do HTTP headers with respect to CORS
-echo "Content-Type: text/plain; charset=utf-8"
-if [[ -n $HTTP_ACCESS_CONTROL_REQUEST_HEADERS ]]; then
-  echo "Access-Control-Allow-Headers: $HTTP_ACCESS_CONTROL_REQUEST_HEADERS"
-fi
-if [[ -n $HTTP_ORIGIN ]]; then
-  echo "Access-Control-Allow-Origin: *"
-fi
-if [[ $REQUEST_METHOD == "OPTIONS" ]]; then {
+if [[ $REQUEST_METHOD == "OPTIONS" ]]; then
+  echo "Content-Type: text/plain; charset=utf-8"
+  print_cors_headers
   echo "Access-Control-Allow-Methods: GET, POST, OPTIONS"
   echo "Content-Length: 0"
   echo
   exit 0
-}; fi
+fi
+
+STATE=
+
+set -f
+IFS=$'&'
+for KEY_VAL in $QUERY_STRING; do
+{
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
+  fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
+  case "$KEY" in
+    osm_base)
+      STATE="$VAL"
+      ;;
+  esac
+}; done
+unset IFS
+set +f
+
+if [[ ! $STATE =~ $TIME_RE ]]; then
+  bad_request "Invalid osm_base parameter"
+fi
+TARGET_TIME="$STATE"
+
+LOWER="0"
+UPPER=$(cat "$LOCAL_DIR/state.txt")
+if [[ ! $UPPER =~ $INTEGER_RE ]]; then
+  internal_error "Invalid state file"
+fi
+
+get_replicate_filename()
+{
+  printf -v TDIGIT3 %03u $((TARGET % 1000))
+  ARG=$((TARGET / 1000))
+  printf -v TDIGIT2 %03u $((ARG % 1000))
+  ARG=$((ARG / 1000))
+  printf -v TDIGIT1 %03u $ARG
+  LOCAL_PATH="$LOCAL_DIR/$TDIGIT1/$TDIGIT2"
+  REPLICATE_FILENAME="$LOCAL_PATH/$TDIGIT3"
+}
+
+update_state()
+{
+  get_replicate_filename
+  if [[ -s "$REPLICATE_FILENAME.state.txt" ]]; then
+    TIMESTAMP_LINE=$(cat "$REPLICATE_FILENAME.state.txt")
+    DATA_VERSION=${TIMESTAMP_LINE:9}
+  fi
+}
+
+while [[ $((LOWER + 1)) -lt $UPPER ]]; do
+  TARGET=$(((LOWER + UPPER) / 2))
+  update_state
+  if [[ -s "$REPLICATE_FILENAME.state.txt" && "$DATA_VERSION" < "$TARGET_TIME" ]]; then
+    LOWER=$TARGET
+  else
+    UPPER=$TARGET
+  fi
+done
+
+echo "Content-Type: text/plain; charset=utf-8"
+print_cors_headers
 echo
 
 echo "$LOWER"

--- a/src/cgi-bin/convert
+++ b/src/cgi-bin/convert
@@ -17,297 +17,285 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
-{
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
-
-BIN_DIR="$EXEC_DIR/../bin"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 DEBUG=
 DATA=
-TARGET=
-ZOOM="6"
-LAT="50.722"
-LON="7.092"
+OUTPUT_TYPE=
 
+set -f
 IFS=$'&'
 for KEY_VAL in $QUERY_STRING; do
 {
-  if [[ ${KEY_VAL:0:7} == "target=" ]]; then
-  {
-    OUTPUT_TYPE="${KEY_VAL:7}"
-  };
-  elif [[ ${KEY_VAL:0:5} == "data=" ]]; then
-  {
-    DATA=`echo "${KEY_VAL:5}" | $BIN_DIR/uncgi`
-  };
-  elif [[ ${KEY_VAL:0:6} == "debug=" ]]; then
-    DEBUG="${KEY_VAL:6}"
-  elif [[ ${KEY_VAL:0:5} == "zoom=" ]]; then
-    ZOOM="${KEY_VAL:5}"
-  elif [[ ${KEY_VAL:0:4} == "lat=" ]]; then
-    LAT="${KEY_VAL:4}"
-  elif [[ ${KEY_VAL:0:4} == "lon=" ]]; then
-    LON="${KEY_VAL:4}"
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
   fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || continue
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || continue
+  case "$KEY" in
+    target)
+      OUTPUT_TYPE="$VAL"
+      ;;
+    data)
+      DATA="$VAL"
+      ;;
+    debug)
+      DEBUG="$VAL"
+      ;;
+  esac
 }; done
 unset IFS
+set +f
 
 if [[ -n $DEBUG ]]; then
-{
-  DEBUG=yes
   echo "Content-Type: text/plain; charset=utf-8"
   echo
   echo "[$DATA]"
-};
 fi
 
-REQUEST_METHOD=
+export REQUEST_METHOD=
 echo "Content-Type: text/html; charset=utf-8"
 echo
 if [[ $OUTPUT_TYPE == "ol_fixed" || $OUTPUT_TYPE == "openlayers" ]]; then
-{
-echo -e "\
-<html>\n\
-<head>\n\
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" lang=\"en\"></meta>\n\
-  <title>OSM3S on Mapnik via Open Layers</title>\n\
-  <script src=\"http://openlayers.org/api/2.11/OpenLayers.js\"></script>\n\
-  <script src=\"http://openstreetmap.org/openlayers/OpenStreetMap.js\"></script>\n\
-  <script src=\"http://overpass-api.de/overpass.js\"></script>\n\
-  <script type=\"text/javascript\">\n\
-      var lat = 53.86;\n\
-      var lon = 8.44;\n\
-      var zoom = 18;\n\
-      var data_url = \"/api/interpreter?data=`echo "$DATA" | ../bin/osm3s_query --dump-compact-ql --concise | ../bin/tocgi `\";\n\
-      var map;\n\
-\n\
-      DetectBoundsOSMFormat = OpenLayers.Class(OpenLayers.Format.OSM, {\n\
-\n\
-          min_lat: 180.0,\n\
-          max_lat: -180.0,\n\
-          min_lon: 90.0,\n\
-          max_lon: -90.0,\n\
-          zoom: 0,\n\
-\n\
-          getNodes: function(doc)\n\
-          {\n\
-            var node_list = doc.getElementsByTagName(\"node\");\n\
-            var nodes = {};\n\
-            for (var i = 0; i < node_list.length; i++)\n\
-            {\n\
-              var node = node_list[i];\n\
-              var id = node.getAttribute(\"id\");\n\
-              nodes[id] = {\n\
-                'lat': node.getAttribute(\"lat\"),\n\
-                'lon': node.getAttribute(\"lon\"),\n\
-                'node': node\n\
-              };\n\
-\n\
-              if (nodes[id].lat < this.min_lat)\n\
-                this.min_lat = nodes[id].lat;\n\
-              if (nodes[id].lat > this.max_lat)\n\
-                this.max_lat = nodes[id].lat;\n\
-              if (nodes[id].lon < this.min_lon)\n\
-                this.min_lon = nodes[id].lon;\n\
-              if (nodes[id].lon > this.max_lon)\n\
-                this.max_lon = nodes[id].lon;\n\
-            }\n\
-\n\
-            if (this.min_lat == 180.0)\n\
-            {\n\
-                this.min_lat = 0;\n\
-                this.max_lat = 0;\n\
-            }\n\
-            if (this.min_lon == 90.0)\n\
-            {\n\
-                this.min_lon = 0;\n\
-                this.max_lon = 0;\n\
-            }\n\
-\n\
-            setStatusText(\"Result contains no nodes.\");\n\
-            return nodes;\n\
-          },          \n\
-\n\
-          CLASS_NAME: \"DetectBoundsOSMFormat\"\n\
-      });\n\
-\n\
-      var osm_format = new DetectBoundsOSMFormat();\n\
-      var layer = \"\";\n\
-\n\
-      function make_features_added_closure() {\n\
-          return function(evt) {\n\
-\n\
-              var lonLat = new OpenLayers.LonLat(\n\
-                  (Number(osm_format.min_lon) + Number(osm_format.max_lon))/2.0,\n\
-                  (Number(osm_format.min_lat) + Number(osm_format.max_lat))/2.0)\n\
-                  .transform(new OpenLayers.Projection(\"EPSG:4326\"), new OpenLayers.Projection(\"EPSG:900913\"));\n\
-\n\
-              var southwest = new OpenLayers.LonLat(\n\
-                  Number(osm_format.min_lon), Number(osm_format.min_lat))\n\
-                  .transform(new OpenLayers.Projection(\"EPSG:4326\"), new OpenLayers.Projection(\"EPSG:900913\"));\n\
-\n\
-              var northeast = new OpenLayers.LonLat(\n\
-                  Number(osm_format.max_lon), Number(osm_format.max_lat))\n\
-                  .transform(new OpenLayers.Projection(\"EPSG:4326\"), new OpenLayers.Projection(\"EPSG:900913\"));\n\
-\n\
-            map.setCenter(lonLat);\n\
-\n\
-            var extent = map.getExtent();\n\
-            extent.extend(southwest);\n\
-            extent.extend(northeast);\n\
-            map.zoomToExtent(extent);\n\
-\n\
-            setStatusText(\"Found \" + layer.features.length + \" features.\");\n\
-          };\n\
-      }\n\
-\n\
-      function init(){\n\
-          map = new OpenLayers.Map (\"map\", {\n\
-          controls:[\n\
-              new OpenLayers.Control.Navigation(),\n\
-              new OpenLayers.Control.PanZoomBar(),\n\
-              new OpenLayers.Control.LayerSwitcher(),\n\
-              new OpenLayers.Control.Attribution()],\n\
-              maxExtent: new OpenLayers.Bounds(-20037508.34,-20037508.34,20037508.34,20037508.34),\n\
-              maxResolution: 156543.0399,\n\
-              numZoomLevels: 19,\n\
-              units: 'm',\n\
-              projection: new OpenLayers.Projection(\"EPSG:900913\"),\n\
-              displayProjection: new OpenLayers.Projection(\"EPSG:4326\")\n\
-          } );\n\
-\n\
-          layerMapnik = new OpenLayers.Layer.OSM.Mapnik(\"Mapnik\");\n\
-          map.addLayer(layerMapnik);\n\
-\n\
-          var lonLat = new OpenLayers.LonLat(lon, lat).transform(new OpenLayers.Projection(\"EPSG:4326\"), new OpenLayers.Projection(\"EPSG:900913\"));\n\
-\n\
-          map.setCenter (lonLat, zoom);\n\
-\n\
-          //Initialise the vector layer using OpenLayers.Format.OSM\n\
-          var styleMap = new OpenLayers.StyleMap({\n\
-              strokeColor: \"blue\",\n\
-              strokeOpacity: 0.5,\n\
-              strokeWidth: 6,\n\
-              pointRadius: 10,\n\
-              fillColor: \"blue\",\n\
-              fillOpacity: 0.25\n\
-          });\n\
-\n\
-          layer = new OpenLayers.Layer.Vector(\"Polygon\", {\n\
-              strategies: [new OpenLayers.Strategy.Fixed()],\n\
-              protocol: new OpenLayers.Protocol.HTTP({\n\
-                  url: data_url,\n\
-                  format: osm_format\n\
-              }),\n\
-              styleMap: styleMap,\n\
-              projection: new OpenLayers.Projection(\"EPSG:4326\")\n\
-          });\n\
-\n\
-          layer.events.register(\"featuresadded\", layer, make_features_added_closure(map, layer));\n\
-\n\
-          map.addLayers([layer]);\n\
-          setStatusText(\"Searching ...\");\n\
-      }\n\
-  </script>\n\
-</head>\n\
-<body onload=\"init()\">\n\
-  <div id=\"statusline\" style=\"font-size:24pt; font-weight:bold; font-family:sans-serif\">No status set yet.</div>\n\
-  <div id=\"map\" class=\"smallmap\"></div>"
-};
+  DATA_URL="/api/interpreter?data=$(printf '%s' "$DATA" | "$BIN_DIR"/osm3s_query --dump-compact-ql --concise | "$BIN_DIR"/tocgi)"
+  cat <<EOF
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" lang="en"></meta>
+  <title>OSM3S on Mapnik via Open Layers</title>
+  <script src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
+  <script src="http://openstreetmap.org/openlayers/OpenStreetMap.js"></script>
+  <script src="http://overpass-api.de/overpass.js"></script>
+  <script type="text/javascript">
+      var lat = 53.86;
+      var lon = 8.44;
+      var zoom = 18;
+      var data_url = "$DATA_URL";
+      var map;
+
+      DetectBoundsOSMFormat = OpenLayers.Class(OpenLayers.Format.OSM, {
+
+          min_lat: 180.0,
+          max_lat: -180.0,
+          min_lon: 90.0,
+          max_lon: -90.0,
+          zoom: 0,
+
+          getNodes: function(doc)
+          {
+            var node_list = doc.getElementsByTagName("node");
+            var nodes = {};
+            for (var i = 0; i < node_list.length; i++)
+            {
+              var node = node_list[i];
+              var id = node.getAttribute("id");
+              nodes[id] = {
+                'lat': node.getAttribute("lat"),
+                'lon': node.getAttribute("lon"),
+                'node': node
+              };
+
+              if (nodes[id].lat < this.min_lat)
+                this.min_lat = nodes[id].lat;
+              if (nodes[id].lat > this.max_lat)
+                this.max_lat = nodes[id].lat;
+              if (nodes[id].lon < this.min_lon)
+                this.min_lon = nodes[id].lon;
+              if (nodes[id].lon > this.max_lon)
+                this.max_lon = nodes[id].lon;
+            }
+
+            if (this.min_lat == 180.0)
+            {
+                this.min_lat = 0;
+                this.max_lat = 0;
+            }
+            if (this.min_lon == 90.0)
+            {
+                this.min_lon = 0;
+                this.max_lon = 0;
+            }
+
+            setStatusText("Result contains no nodes.");
+            return nodes;
+          },
+
+          CLASS_NAME: "DetectBoundsOSMFormat"
+      });
+
+      var osm_format = new DetectBoundsOSMFormat();
+      var layer = "";
+
+      function make_features_added_closure() {
+          return function(evt) {
+
+              var lonLat = new OpenLayers.LonLat(
+                  (Number(osm_format.min_lon) + Number(osm_format.max_lon))/2.0,
+                  (Number(osm_format.min_lat) + Number(osm_format.max_lat))/2.0)
+                  .transform(new OpenLayers.Projection("EPSG:4326"), new OpenLayers.Projection("EPSG:900913"));
+
+              var southwest = new OpenLayers.LonLat(
+                  Number(osm_format.min_lon), Number(osm_format.min_lat))
+                  .transform(new OpenLayers.Projection("EPSG:4326"), new OpenLayers.Projection("EPSG:900913"));
+
+              var northeast = new OpenLayers.LonLat(
+                  Number(osm_format.max_lon), Number(osm_format.max_lat))
+                  .transform(new OpenLayers.Projection("EPSG:4326"), new OpenLayers.Projection("EPSG:900913"));
+
+            map.setCenter(lonLat);
+
+            var extent = map.getExtent();
+            extent.extend(southwest);
+            extent.extend(northeast);
+            map.zoomToExtent(extent);
+
+            setStatusText("Found " + layer.features.length + " features.");
+          };
+      }
+
+      function init(){
+          map = new OpenLayers.Map ("map", {
+          controls:[
+              new OpenLayers.Control.Navigation(),
+              new OpenLayers.Control.PanZoomBar(),
+              new OpenLayers.Control.LayerSwitcher(),
+              new OpenLayers.Control.Attribution()],
+              maxExtent: new OpenLayers.Bounds(-20037508.34,-20037508.34,20037508.34,20037508.34),
+              maxResolution: 156543.0399,
+              numZoomLevels: 19,
+              units: 'm',
+              projection: new OpenLayers.Projection("EPSG:900913"),
+              displayProjection: new OpenLayers.Projection("EPSG:4326")
+          } );
+
+          layerMapnik = new OpenLayers.Layer.OSM.Mapnik("Mapnik");
+          map.addLayer(layerMapnik);
+
+          var lonLat = new OpenLayers.LonLat(lon, lat).transform(new OpenLayers.Projection("EPSG:4326"), new OpenLayers.Projection("EPSG:900913"));
+
+          map.setCenter (lonLat, zoom);
+
+          //Initialise the vector layer using OpenLayers.Format.OSM
+          var styleMap = new OpenLayers.StyleMap({
+              strokeColor: "blue",
+              strokeOpacity: 0.5,
+              strokeWidth: 6,
+              pointRadius: 10,
+              fillColor: "blue",
+              fillOpacity: 0.25
+          });
+
+          layer = new OpenLayers.Layer.Vector("Polygon", {
+              strategies: [new OpenLayers.Strategy.Fixed()],
+              protocol: new OpenLayers.Protocol.HTTP({
+                  url: data_url,
+                  format: osm_format
+              }),
+              styleMap: styleMap,
+              projection: new OpenLayers.Projection("EPSG:4326")
+          });
+
+          layer.events.register("featuresadded", layer, make_features_added_closure(map, layer));
+
+          map.addLayers([layer]);
+          setStatusText("Searching ...");
+      }
+  </script>
+</head>
+<body onload="init()">
+  <div id="statusline" style="font-size:24pt; font-weight:bold; font-family:sans-serif">No status set yet.</div>
+  <div id="map" class="smallmap"></div>
+EOF
 elif [[ $OUTPUT_TYPE == "ol_bbox" ]]; then
-{
-echo -e "\
-<html>\n\
-<head>\n\
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" lang=\"en\"></meta>\n\
-  <title>OSM3S on Mapnik via Open Layers</title>\n\
-  <script src=\"http://openlayers.org/api/OpenLayers.js\"></script>\n\
-  <script src=\"http://openstreetmap.org/openlayers/OpenStreetMap.js\"></script>\n\
-  <script src=\"http://overpass-api.de/overpass.js\"></script>\n\
-  <script type=\"text/javascript\">\n\
-      var lat = 51.0;\n\
-      var lon = 10.5;\n\
-      var zoom = 6;\n\
-      var map;\n\
-\n\
-      function init(){\n\
-          map = new OpenLayers.Map (\"map\", {\n\
-          controls:[\n\
-              new OpenLayers.Control.Navigation(),\n\
-              new OpenLayers.Control.PanZoomBar(),\n\
-              new OpenLayers.Control.LayerSwitcher(),\n\
-              new OpenLayers.Control.Attribution()],\n\
-              maxExtent: new OpenLayers.Bounds(-20037508.34,-20037508.34,20037508.34,20037508.34),\n\
-              maxResolution: 156543.0399,\n\
-              numZoomLevels: 19,\n\
-              units: 'm',\n\
-              projection: new OpenLayers.Projection(\"EPSG:900913\"),\n\
-              displayProjection: new OpenLayers.Projection(\"EPSG:4326\")\n\
-          } );\n\
-\n\
-          layerMapnik = new OpenLayers.Layer.OSM.Mapnik(\"Mapnik\");\n\
-          map.addLayer(layerMapnik);\n\
-\n\
-          var lonLat = new OpenLayers.LonLat(lon, lat)\n\
-              .transform(new OpenLayers.Projection(\"EPSG:4326\"), new OpenLayers.Projection(\"EPSG:900913\"));\n\
-\n\
-          map.setCenter (lonLat, zoom);\n\
-\n\
-          map.addLayers([\n\
-              make_layer(\"/api/interpreter?data=`echo "$DATA" | ../bin/osm3s_query --dump-bbox-ql --concise | ../bin/tocgi `\", \"blue\")\n\
-          ]);\n\
-      }\n\
-  </script>\n\
-</head>\n\
-<body onload=\"init()\">\n\
-  <div id=\"statusline\" style=\"font-size:24pt; font-weight:bold; font-family:sans-serif\">No status set yet.</div>\n\
-  <div id=\"map\" class=\"smallmap\"></div>"
-};
+  DATA_URL="/api/interpreter?data=$(printf '%s' "$DATA" | "$BIN_DIR"/osm3s_query --dump-bbox-ql --concise | "$BIN_DIR"/tocgi)"
+  cat <<EOF
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" lang="en"></meta>
+  <title>OSM3S on Mapnik via Open Layers</title>
+  <script src="http://openlayers.org/api/OpenLayers.js"></script>
+  <script src="http://openstreetmap.org/openlayers/OpenStreetMap.js"></script>
+  <script src="http://overpass-api.de/overpass.js"></script>
+  <script type="text/javascript">
+      var lat = 51.0;
+      var lon = 10.5;
+      var zoom = 6;
+      var map;
+
+      function init(){
+          map = new OpenLayers.Map ("map", {
+          controls:[
+              new OpenLayers.Control.Navigation(),
+              new OpenLayers.Control.PanZoomBar(),
+              new OpenLayers.Control.LayerSwitcher(),
+              new OpenLayers.Control.Attribution()],
+              maxExtent: new OpenLayers.Bounds(-20037508.34,-20037508.34,20037508.34,20037508.34),
+              maxResolution: 156543.0399,
+              numZoomLevels: 19,
+              units: 'm',
+              projection: new OpenLayers.Projection("EPSG:900913"),
+              displayProjection: new OpenLayers.Projection("EPSG:4326")
+          } );
+
+          layerMapnik = new OpenLayers.Layer.OSM.Mapnik("Mapnik");
+          map.addLayer(layerMapnik);
+
+          var lonLat = new OpenLayers.LonLat(lon, lat)
+              .transform(new OpenLayers.Projection("EPSG:4326"), new OpenLayers.Projection("EPSG:900913"));
+
+          map.setCenter (lonLat, zoom);
+
+          map.addLayers([
+              make_layer("$DATA_URL", "blue")
+          ]);
+      }
+  </script>
+</head>
+<body onload="init()">
+  <div id="statusline" style="font-size:24pt; font-weight:bold; font-family:sans-serif">No status set yet.</div>
+  <div id="map" class="smallmap"></div>
+EOF
 else
-{
-  echo -e "\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n\
-	\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n\
-<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n\
-<head>\n\
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" lang=\"en\"></meta>\n\
-  <title>OSM3S Converted Query</title>\n\
-</head>\n\
-<body>\n\
-\n\
-<h1>Overpass API Converted Query</h1>\n\
-"
+  cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" lang="en"></meta>
+  <title>OSM3S Converted Query</title>
+</head>
+<body>
+
+<h1>Overpass API Converted Query</h1>
+
+EOF
 
   if [[ $OUTPUT_TYPE == "xml" ]]; then
-  {
     echo "<p>Your query in pretty XML:</p>"
     echo "<pre>"
-    echo "$DATA" | ../bin/osm3s_query --dump-xml --concise | ../bin/escape_xml
+    printf '%s\n' "$DATA" | "$BIN_DIR"/osm3s_query --dump-xml --concise | "$BIN_DIR"/escape_xml
     echo "</pre>"
-  };
   elif [[ $OUTPUT_TYPE == "mapql" ]]; then
-  {
     echo "<p>Your query in pretty Overpass QL:</p>"
     echo "<pre>"
-    echo -n "$DATA" | ../bin/osm3s_query --dump-pretty-ql --concise | ../bin/escape_xml
+    printf '%s' "$DATA" | "$BIN_DIR"/osm3s_query --dump-pretty-ql --concise | "$BIN_DIR"/escape_xml
     echo "</pre>"
-  };
   elif [[ $OUTPUT_TYPE == "compact" ]]; then
-  {
     echo "<p>Your query in compact Overpass QL:</p>"
-    echo "<a href=\"interpreter?data=`echo "$DATA" | ../bin/osm3s_query --dump-compact-ql --concise | ../bin/tocgi `\"><pre>"
-    echo -n "$DATA" | ../bin/osm3s_query --dump-compact-ql --concise | ../bin/escape_xml 
+    DATA_HREF="$(printf '%s' "$DATA" | "$BIN_DIR"/osm3s_query --dump-compact-ql --concise | "$BIN_DIR"/tocgi)"
+    echo "<a href=\"interpreter?data=$DATA_HREF\"><pre>"
+    printf '%s' "$DATA" | "$BIN_DIR"/osm3s_query --dump-compact-ql --concise | "$BIN_DIR"/escape_xml
     echo "</pre></a>"
-  };
   fi
-};
 fi
 
-echo -e "\n\
-</body>\n\
-</html>\n\
-\n"
+cat <<'EOF'
+
+</body>
+</html>
+
+
+EOF

--- a/src/cgi-bin/convert_xapi
+++ b/src/cgi-bin/convert_xapi
@@ -17,86 +17,67 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
-{
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
-BIN_DIR="$EXEC_DIR/../bin"
+report_error()
+{
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo
+  echo "Error in [$BUF]:"
+  printf '%s\n' "$1"
+  [[ -n $REQUEST_FILE ]] && rm -f "$REQUEST_FILE"
+  exit 1
+}
 
 OUTPUT_TYPE="xml"
-BUF="`echo "$QUERY_STRING" | $BIN_DIR/uncgi`"
+BUF=$(printf '%s' "$QUERY_STRING" | "$BIN_DIR"/uncgi) || report_error "Malformed query string"
 if [[ "${BUF:0:5}" == "debug" ]]; then
-{
   DEBUG=yes
   echo "Content-Type: text/plain; charset=utf-8"
   echo
   BUF="${BUF:6}"
   echo "[$BUF]"
-};
 elif [[ "${BUF:0:3}" == "xml" ]]; then
-{
-  OTUPUT_TYPE="xml"
+  OUTPUT_TYPE="xml"
   BUF="${BUF:4}"
-};
 elif [[ "${BUF:0:5}" == "mapql" ]]; then
-{
-  OTUPUT_TYPE="mapql"
+  OUTPUT_TYPE="mapql"
   BUF="${BUF:6}"
-};
 elif [[ "${BUF:0:7}" == "compact" ]]; then
-{
-  OTUPUT_TYPE="compact"
+  OUTPUT_TYPE="compact"
   BUF="${BUF:8}"
-};
 fi
 
 # No mkdir - directory should be created and made world-writeable
 # by the maintainer to allow periodic cleanups.
-REQUEST_FILE=`mktemp /tmp/translate_xapi/XXXXXX`
-$BIN_DIR/translate_xapi "${BUF}" >$REQUEST_FILE
+REQUEST_FILE=$(mktemp /tmp/translate_xapi/XXXXXX) || report_error "Could not create temporary file"
+"$BIN_DIR"/translate_xapi "$BUF" >"$REQUEST_FILE"
 EXITCODE=$?
 if [[ $EXITCODE -ne 0 ]]; then
-{
-  echo "Content-Type: text/plain; charset=utf-8"
-  echo
-  echo "Error in [$BUF]:"
-  cat <$REQUEST_FILE
-};
-else
-{
-  if [[ $DEBUG == "yes" ]]; then
-  {
-    cat <$REQUEST_FILE
-    echo
-  };
-  fi
-  REQUEST_METHOD=
-  echo "Content-Type: text/plain; charset=utf-8"
-  echo
-  if [[ $OUTPUT_TYPE == "xml" ]]; then
-  {
-    echo "Your query in pretty XML:"
-    echo
-    ../bin/osm3s_query --dump-xml <$REQUEST_FILE
-  };
-  elif [[ $OUTPUT_TYPE == "mapql" ]]; then
-  {
-    echo "Your query in pretty OverpassQL:"
-    echo
-    ../bin/osm3s_query --dump-pretty-ql <$REQUEST_FILE
-  };
-  elif [[ $OUTPUT_TYPE == "compact" ]]; then
-  {
-    echo "Your query in compact OverpassQL:"
-    echo
-    ../bin/osm3s_query --dump-compact-ql <$REQUEST_FILE
-    echo
-  };
-  fi
-};
+  report_error "$(cat "$REQUEST_FILE")"
 fi
 
-rm $REQUEST_FILE
+if [[ $DEBUG == "yes" ]]; then
+  cat "$REQUEST_FILE"
+  echo
+fi
+export REQUEST_METHOD=
+echo "Content-Type: text/plain; charset=utf-8"
+echo
+if [[ $OUTPUT_TYPE == "xml" ]]; then
+  echo "Your query in pretty XML:"
+  echo
+  "$BIN_DIR"/osm3s_query --dump-xml <"$REQUEST_FILE"
+elif [[ $OUTPUT_TYPE == "mapql" ]]; then
+  echo "Your query in pretty OverpassQL:"
+  echo
+  "$BIN_DIR"/osm3s_query --dump-pretty-ql <"$REQUEST_FILE"
+elif [[ $OUTPUT_TYPE == "compact" ]]; then
+  echo "Your query in compact OverpassQL:"
+  echo
+  "$BIN_DIR"/osm3s_query --dump-compact-ql <"$REQUEST_FILE"
+  echo
+fi
+
+rm -f "$REQUEST_FILE"

--- a/src/cgi-bin/draw-line
+++ b/src/cgi-bin/draw-line
@@ -17,107 +17,118 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PT_Diagrams.  If not, see <http://www.gnu.org/licenses/>.
 
-BUF="$QUERY_STRING&"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
+NUMBER_RE='-?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][+-]?[0-9]+)?'
+NUMERIC_RE="^${NUMBER_RE}\$"
+
+NETWORK_=
+REF_=
 SKETCH_PARAMS=
-BRIM_PARAMS=
+DEBUG=
+BASEDIR=
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
+fail()
 {
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo
+  echo "$1"
+  [[ -n $BASEDIR ]] && rm -rf "$BASEDIR"
+  exit 0
+}
 
-BIN_DIR="$EXEC_DIR/../bin"
-
+set -f
 IFS=$'&'
 for KEY_VAL in $QUERY_STRING; do
 {
-  if [[ ${KEY_VAL:0:8} == "network=" ]]; then
-  {
-    NETWORK="${KEY_VAL:8}"
-    NETWORK_=`echo "${KEY_VAL:8}" | $BIN_DIR/uncgi`
-  };
-  elif [[ ${KEY_VAL:0:4} == "ref=" ]]; then
-  {
-    REF="${KEY_VAL:4}"
-    REF_=`echo "${KEY_VAL:4}" | $BIN_DIR/uncgi`
-  };
-  elif [[ ${KEY_VAL:0:10} == "pivot-lon=" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --pivot-lon=${KEY_VAL:10}"
-  elif [[ ${KEY_VAL:0:6} == "scale=" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --scale=${KEY_VAL:6}"
-  elif [[ ${KEY_VAL:0:10} == "font-size=" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --stop-font-size=${KEY_VAL:10}"
-  elif [[ ${KEY_VAL:0:6} == "debug=" ]]; then
-    DEBUG="${KEY_VAL:6}"
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
   fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+  case "$KEY" in
+    network)
+      NETWORK_=$(printf '%s' "$VAL" | "$BIN_DIR"/escape_xml)
+      ;;
+    ref)
+      REF_=$(printf '%s' "$VAL" | "$BIN_DIR"/escape_xml)
+      ;;
+    pivot-lon)
+      if [[ $VAL =~ $NUMERIC_RE ]]; then
+        SKETCH_PARAMS="$SKETCH_PARAMS --pivot-lon=$VAL"
+      else
+        fail "Invalid pivot-lon parameter."
+      fi
+      ;;
+    scale)
+      if [[ $VAL =~ $NUMERIC_RE ]]; then
+        SKETCH_PARAMS="$SKETCH_PARAMS --scale=$VAL"
+      else
+        fail "Invalid scale parameter."
+      fi
+      ;;
+    font-size)
+      if [[ $VAL =~ $NUMERIC_RE ]]; then
+        SKETCH_PARAMS="$SKETCH_PARAMS --stop-font-size=$VAL"
+      else
+        fail "Invalid font-size parameter."
+      fi
+      ;;
+    debug)
+      DEBUG="$VAL"
+      ;;
+  esac
 }; done
 unset IFS
+set +f
 
-BASEDIR=`mktemp -d /tmp/osm3s_draw_line_XXXXXX`
+if [[ -z $REF_ ]]; then
+  fail "An empty value for ref is not allowed."
+fi
 
-echo -e "\
-<osm-script> \
- \
-<union> \
-  <query type=\"relation\"> \
-    <has-kv k=\"network\" v=\"$NETWORK_\"/> \
-    <has-kv k=\"ref\" v=\"$REF_\"/> \
-  </query> \
-  <recurse type=\"relation-node\" into=\"__\"/> \
-  <recurse type=\"relation-way\"/> \
-  <recurse type=\"way-node\"/> \
-</union> \
-<print mode=\"body\"/> \
- \
+BASEDIR=$(mktemp -d /tmp/osm3s_draw_line_XXXXXX) || fail "Could not create temporary directory."
+
+cat >"$BASEDIR/request.1" <<EOF
+<osm-script>
+<union>
+  <query type="relation">
+    <has-kv k="network" v="$NETWORK_"/>
+    <has-kv k="ref" v="$REF_"/>
+  </query>
+  <recurse type="relation-node" into="__"/>
+  <recurse type="relation-way"/>
+  <recurse type="way-node"/>
+</union>
+<print mode="body"/>
 </osm-script>
-" >$BASEDIR/request.1
+EOF
 
-if [[ -z $REF ]]; then
-{                     
-  echo "Content-Type: text/plain; charset=utf-8"
-  echo                                          
-  echo "An empty value for ref is not allowed."  
-
-  exit 0
-};    
-fi      
-
-CORRESPONDENCES= #`$BIN_DIR/bbox_brim_query --only-corrs $BRIM_PARAMS`
+CORRESPONDENCES= #$("$BIN_DIR"/bbox_brim_query --only-corrs $BRIM_PARAMS)
 
 if [[ $CORRESPONDENCES -gt 0 ]]; then
-{
+  fail "Correspondences are for the geographical map currently not supported."
+fi
+
+export REQUEST_METHOD=
+if [[ $DEBUG == "full-query" ]]; then
   echo "Content-Type: text/plain; charset=utf-8"
-  echo                                          
-  echo "Correspondences are for the geographical map currently not supported."  
-
-  exit 0
-};
-else
-{
-  if [[ $DEBUG == "full-query" ]]; then
-  {
-    echo "Content-Type: text/plain; charset=utf-8"
-    echo
-
-    REQUEST_METHOD=
-    $BIN_DIR/osm3s_query <$BASEDIR/request.1 2>&1
-
-    echo
-    echo "$BIN_DIR/draw_route_svg $SKETCH_PARAMS"
-  };
-  else
-  {
-    REQUEST_METHOD=
-    $BIN_DIR/osm3s_query --quiet <$BASEDIR/request.1 >$BASEDIR/answer.1
-  };
-  fi;
-
-  echo "Content-Type: image/svg+xml; charset=utf-8"
   echo
 
-  $BIN_DIR/draw_route_svg $SKETCH_PARAMS <$BASEDIR/answer.1
-};
+  "$BIN_DIR"/osm3s_query <"$BASEDIR/request.1" 2>&1
+
+  echo
+  echo "$BIN_DIR/draw_route_svg $SKETCH_PARAMS"
+else
+  "$BIN_DIR"/osm3s_query --quiet <"$BASEDIR/request.1" >"$BASEDIR/answer.1"
 fi
+
+echo "Content-Type: image/svg+xml; charset=utf-8"
+echo
+
+# shellcheck disable=SC2086 # SKETCH_PARAMS holds space-separated, regex-validated numeric flags
+"$BIN_DIR"/draw_route_svg $SKETCH_PARAMS <"$BASEDIR/answer.1"
+
+rm -rf "$BASEDIR"

--- a/src/cgi-bin/kill_my_queries
+++ b/src/cgi-bin/kill_my_queries
@@ -17,33 +17,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
-{
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
-BIN_DIR="$EXEC_DIR/../bin"
+PID_RE='^[0-9]+$'
 
 echo "Content-Type: text/plain; charset=utf-8"
 echo 'Access-Control-Allow-Origin: *'
 echo
 
 COUNTER=16
-PID=`$BIN_DIR/dispatcher --query_token`
+PID=$("$BIN_DIR"/dispatcher --query_token)
 
-if [[ $PID == 0 ]]; then
+if [[ -z $PID ]]; then
   echo "No query running from IP $REMOTE_ADDR"
 fi
 
-while [[ $PID -ne 0 && $COUNTER -gt 0 ]]; do
-{
+while [[ $PID =~ $PID_RE && $COUNTER -gt 0 ]]; do
   echo "Killing query (pid $PID) from IP $REMOTE_ADDR ..."
-  kill -9 $PID
+  kill -9 "$PID"
   echo "Done!"
-  
-  COUNTER=$(($COUNTER - 1))
-  PID=`$BIN_DIR/dispatcher --query_token`
-};
+
+  COUNTER=$((COUNTER - 1))
+  PID=$("$BIN_DIR"/dispatcher --query_token)
 done
+
+if [[ -n $PID && ! $PID =~ $PID_RE ]]; then
+  echo "Could not query dispatcher: $PID"
+fi

--- a/src/cgi-bin/map
+++ b/src/cgi-bin/map
@@ -17,13 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
-{
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+EXEC_DIR="$(dirname "$(realpath "$0")")"
 
 QUERY_STRING="data=[bbox];(node(bbox);way(bn);node(w););(._;(rel(bn)->.a;rel(bw)->.a;);rel(br););out meta;&$QUERY_STRING"
 
-./interpreter
+"$EXEC_DIR"/interpreter

--- a/src/cgi-bin/ping
+++ b/src/cgi-bin/ping
@@ -22,50 +22,61 @@
 fetch_file()
 {
   wget -q -O "$2" "$1"
-};
+}
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
+fetch_and_output_result()
 {
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+  if fetch_file "$1" "$PING_FILE"; then
+    "$BIN_DIR"/escape_xml <"$PING_FILE"
+  else
+    echo "Fetch failed."
+  fi
+}
 
-BIN_DIR="$EXEC_DIR/../bin"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
 # Set BASE_URL to your own server's external name
 BASE_URL="http://localhost/api"
 
+PING_FILE=$(mktemp /tmp/osm3s_ping_XXXXXX) || exit 1
+trap 'rm -f "$PING_FILE"' EXIT
+
 echo "Content-Type: text/html; charset=utf-8"
 echo
-echo -e "\
-<html>\n\
-<head>\n\
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" lang=\"en\"></meta>\n\
-  <title>Server status</title>\n\
-</head>\n\
-<body>\n\
-  <h1>Outside view on the server</h1>\n\
-  <h2>Empty, simple request</h2>\n\
-<pre>\n"
+cat <<EOF
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" lang="en"></meta>
+  <title>Server status</title>
+</head>
+<body>
+  <h1>Outside view on the server</h1>
+  <h2>Empty, simple request</h2>
+<pre>
 
-fetch_file "$BASE_URL/interpreter?data=<print/>" "/tmp/ping.xml"
-$BIN_DIR/escape_xml <"/tmp/ping.xml"
+EOF
 
-echo -e "</pre>\
-  <h2>Meta request</h2>\n\
-<pre>\n"
+fetch_and_output_result "$BASE_URL/interpreter?data=<print/>"
 
-fetch_file "$BASE_URL/interpreter?data=<query type='way'><has-kv k='name' v='Lipkenskothen'/></query><print mode='meta'/><recurse type='way-node'/><print mode='meta'/>" "/tmp/ping.xml"
-$BIN_DIR/escape_xml <"/tmp/ping.xml"
+cat <<EOF
+</pre>  <h2>Meta request</h2>
+<pre>
 
-echo -e "</pre>\
-  <h2>Area request</h2>\n\
-<pre>\n"
+EOF
 
-fetch_file "$BASE_URL/interpreter?data=<coord-query lat='51.25' lon='7.15'/><print mode='ids_only'/>" "/tmp/ping.xml"
-$BIN_DIR/escape_xml <"/tmp/ping.xml"
+fetch_and_output_result "$BASE_URL/interpreter?data=<query type='way'><has-kv k='name' v='Lipkenskothen'/></query><print mode='meta'/><recurse type='way-node'/><print mode='meta'/>"
 
-echo -e "</pre>\
-</body>\n\
-</html>\n"
+cat <<EOF
+</pre>  <h2>Area request</h2>
+<pre>
+
+EOF
+
+fetch_and_output_result "$BASE_URL/interpreter?data=<coord-query lat='51.25' lon='7.15'/><print mode='ids_only'/>"
+
+cat <<EOF
+</pre></body>
+</html>
+
+EOF

--- a/src/cgi-bin/sitemap
+++ b/src/cgi-bin/sitemap
@@ -17,38 +17,39 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-BASE_DIR="/var/www/"
+shopt -s nullglob
+
+BASE_DIR="/var/www"
 
 echo "Content-Type: application/xml; charset=utf-8"
 echo
-echo -e "\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\n\
-  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n\
-  xsi:schemaLocation=\"http://www.sitemaps.org/schemas/sitemap/0.9\n\
-      http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\">\n\
-\n\
-  <url>\n\
-    <loc>http://overpass-api.de/</loc>\n\
-    <lastmod>`date -r $BASE_DIR/index.html +%F`</lastmod>\n\
-    <changefreq>monthly</changefreq>\n\
-  </url>"
+cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+      http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+
+  <url>
+    <loc>http://overpass-api.de/</loc>
+    <lastmod>$(date -r "$BASE_DIR/index.html" +%F)</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+EOF
 
 for I in "$BASE_DIR"/*.html; do
-{
-  if [[ $I != "$BASE_DIR"/index.html && $I != "$BASE_DIR"/google271f53434c229fc4.html ]]; then
-  {
-    echo -e "\
-\n\
-  <url>\n\
-    <loc>http://overpass-api.de/`basename $I`</loc>\n\
-    <lastmod>`date -r $I +%F`</lastmod>\n\
-    <changefreq>monthly</changefreq>\n\
-  </url>"
+  if [[ $I != "$BASE_DIR/index.html" && $I != "$BASE_DIR/google271f53434c229fc4.html" ]]; then
+    cat <<EOF
 
-  }; fi
-}; done
+  <url>
+    <loc>http://overpass-api.de/$(basename "$I")</loc>
+    <lastmod>$(date -r "$I" +%F)</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+EOF
+  fi
+done
 
-echo -e "\n\
-</urlset>\n\
-"
+echo
+echo "</urlset>"
+echo

--- a/src/cgi-bin/sketch-line
+++ b/src/cgi-bin/sketch-line
@@ -17,119 +17,151 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PT_Diagrams.  If not, see <http://www.gnu.org/licenses/>.
 
-BUF="$QUERY_STRING&"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
+STYLE_DIR=/opt/pt_diagrams
+
+NUMBER_RE='-?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][+-]?[0-9]+)?'
+NUMERIC_RE="^${NUMBER_RE}\$"
+STYLE_RE='[/ ]'
+
+NETWORK_=
+REF_=
+OPERATOR_=
 SKETCH_PARAMS=
 BRIM_PARAMS=
-STYLE_DIR=/opt/pt_diagrams/
+DEBUG=
+BASEDIR=
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
+fail()
 {
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo
+  echo "$1"
+  [[ -n $BASEDIR ]] && rm -rf "$BASEDIR"
+  exit 0
+}
 
-BIN_DIR="$EXEC_DIR/../bin"
-
+set -f
 IFS=$'&'
-NETWORK=
-NETWORK_=
-REF=
-REF_=
-OPERATOR=
-OPERATOR_=
 for KEY_VAL in $QUERY_STRING; do
 {
-  if [[ ${KEY_VAL:0:8} == "network=" ]]; then
-  {
-    NETWORK="${KEY_VAL:8}"
-    NETWORK_=`echo "${KEY_VAL:8}" | $BIN_DIR/uncgi`
-  };
-  elif [[ ${KEY_VAL:0:4} == "ref=" ]]; then
-  {
-    REF="${KEY_VAL:4}"
-    REF_=`echo "${KEY_VAL:4}" | $BIN_DIR/uncgi`
-  };
-  elif [[ ${KEY_VAL:0:9} == "operator=" ]]; then
-  {
-    OPERATOR="${KEY_VAL:9}"
-    OPERATOR_=`echo "${KEY_VAL:9}" | $BIN_DIR/uncgi`
-  };
-  elif [[ ${KEY_VAL:0:6} == "width=" && -n "${KEY_VAL:6}" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --width=${KEY_VAL:6}"
-  elif [[ ${KEY_VAL:0:7} == "height=" && -n "${KEY_VAL:7}" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --height=${KEY_VAL:7}"
-  elif [[ ${KEY_VAL:0:10} == "font-size=" && -n "${KEY_VAL:10}" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --stop-font-size=${KEY_VAL:10}"
-  elif [[ ${KEY_VAL:0:11} == "force-rows=" && -n "${KEY_VAL:11}" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --rows=${KEY_VAL:11}"
-  elif [[ ${KEY_VAL:0:6} == "style=" && -n "${KEY_VAL:6}" ]]; then
-  {
-    SKETCH_PARAMS="$SKETCH_PARAMS --options=$STYLE_DIR/sketch-line.${KEY_VAL:6}"
-    BRIM_PARAMS="$BRIM_PARAMS --options=$STYLE_DIR/sketch-line.${KEY_VAL:6}"
-  };
-  elif [[ ${KEY_VAL:0:16} == "correspondences=" && -n "${KEY_VAL:16}" ]]; then
-  {
-    SKETCH_PARAMS="$SKETCH_PARAMS --walk-limit=${KEY_VAL:16}"
-    BRIM_PARAMS="$BRIM_PARAMS --size=${KEY_VAL:16}"
-  };
-  elif [[ ${KEY_VAL:0:18} == "max-cors-per-line=" && -n "${KEY_VAL:18}" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --max-correspondences-per-line=${KEY_VAL:18}"
-  elif [[ ${KEY_VAL:0:15} == "max-cors-below=" && -n "${KEY_VAL:15}" ]]; then
-    SKETCH_PARAMS="$SKETCH_PARAMS --max-correspondences-below=${KEY_VAL:15}"
-  elif [[ ${KEY_VAL:0:6} == "debug=" && -n "${KEY_VAL:6}" ]]; then
-  {
-    SKETCH_PARAMS="$SKETCH_PARAMS --debug=${KEY_VAL:6}"
-    DEBUG="${KEY_VAL:6}"
-  };
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
   fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+  case "$KEY" in
+    network)
+      NETWORK_="$VAL"
+      ;;
+    ref)
+      REF_="$VAL"
+      ;;
+    operator)
+      OPERATOR_="$VAL"
+      ;;
+    width)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $NUMERIC_RE ]] || fail "Invalid width parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --width=$VAL"
+      fi
+      ;;
+    height)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $NUMERIC_RE ]] || fail "Invalid height parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --height=$VAL"
+      fi
+      ;;
+    font-size)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $NUMERIC_RE ]] || fail "Invalid font-size parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --stop-font-size=$VAL"
+      fi
+      ;;
+    force-rows)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $NUMERIC_RE ]] || fail "Invalid force-rows parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --rows=$VAL"
+      fi
+      ;;
+    style)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $STYLE_RE ]] && fail "Invalid style parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --options=$STYLE_DIR/sketch-line.$VAL"
+        BRIM_PARAMS="$BRIM_PARAMS --options=$STYLE_DIR/sketch-line.$VAL"
+      fi
+      ;;
+    correspondences)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $NUMERIC_RE ]] || fail "Invalid correspondences parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --walk-limit=$VAL"
+        BRIM_PARAMS="$BRIM_PARAMS --size=$VAL"
+      fi
+      ;;
+    max-cors-per-line)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $NUMERIC_RE ]] || fail "Invalid max-cors-per-line parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --max-correspondences-per-line=$VAL"
+      fi
+      ;;
+    max-cors-below)
+      if [[ -n $VAL ]]; then
+        [[ $VAL =~ $NUMERIC_RE ]] || fail "Invalid max-cors-below parameter"
+        SKETCH_PARAMS="$SKETCH_PARAMS --max-correspondences-below=$VAL"
+      fi
+      ;;
+    debug)
+      if [[ -n $VAL ]]; then
+        SKETCH_PARAMS="$SKETCH_PARAMS --debug=$VAL"
+        DEBUG="$VAL"
+      fi
+      ;;
+  esac
 }; done
 unset IFS
+set +f
 
-BASEDIR=`mktemp -d /tmp/osm3s_sketch_line_XXXXXX`
-
-if [[ -z $REF ]]; then
-{                     
-  echo "Content-Type: text/plain; charset=utf-8"
-  echo                                          
-  echo "An empty value for ref is not allowed"  
-
-  exit 0
-};    
-fi      
-
-if [[ $DEBUG == "yes" ]]; then
-{
-  echo "Content-Type: text/plain; charset=utf-8"
-  echo
-  echo $BIN_DIR/bbox_brim_query --network=\"$NETWORK_\" --ref=\"$REF_\" --operator=\"$OPERATOR_\" $BRIM_PARAMS ">"$BASEDIR/request.1
-  echo
-};
+if [[ -z $REF_ ]]; then
+  fail "An empty value for ref is not allowed"
 fi
 
-$BIN_DIR/bbox_brim_query --network="$NETWORK_" --ref="$REF_" --operator="$OPERATOR_" $BRIM_PARAMS >$BASEDIR/request.1
-
-REQUEST_METHOD=
+BASEDIR=$(mktemp -d /tmp/osm3s_sketch_line_XXXXXX) || fail "Could not create temporary directory"
 
 if [[ $DEBUG == "yes" ]]; then
-{
-  cat <$BASEDIR/request.1
+  echo "Content-Type: text/plain; charset=utf-8"
   echo
-  echo $BIN_DIR/osm3s_query --verbose "<"$BASEDIR/request.1 ">"$BASEDIR/answer.1
+  echo "$BIN_DIR/bbox_brim_query --network=\"$NETWORK_\" --ref=\"$REF_\" --operator=\"$OPERATOR_\" $BRIM_PARAMS >$BASEDIR/request.1"
   echo
-  $BIN_DIR/osm3s_query --verbose <$BASEDIR/request.1 >$BASEDIR/answer.1 2>$BASEDIR/log.1
+fi
+
+# shellcheck disable=SC2086 # BRIM_PARAMS holds space-separated, validated flags
+"$BIN_DIR"/bbox_brim_query --network="$NETWORK_" --ref="$REF_" --operator="$OPERATOR_" $BRIM_PARAMS >"$BASEDIR/request.1"
+
+export REQUEST_METHOD=
+
+if [[ $DEBUG == "yes" ]]; then
+  cat "$BASEDIR/request.1"
   echo
-  cat <$BASEDIR/log.1
-  cat <$BASEDIR/answer.1
-  echo $BIN_DIR/sketch_route_svg --network=\"$NETWORK_\" --ref=\"$REF_\" $SKETCH_PARAMS <$BASEDIR/answer.1
+  echo "$BIN_DIR/osm3s_query --verbose <$BASEDIR/request.1 >$BASEDIR/answer.1"
   echo
-};
+  "$BIN_DIR"/osm3s_query --verbose <"$BASEDIR/request.1" >"$BASEDIR/answer.1" 2>"$BASEDIR/log.1"
+  echo
+  cat "$BASEDIR/log.1"
+  cat "$BASEDIR/answer.1"
+  echo "$BIN_DIR/sketch_route_svg --network=\"$NETWORK_\" --ref=\"$REF_\" $SKETCH_PARAMS <$BASEDIR/answer.1"
+  echo
 else
-  $BIN_DIR/osm3s_query --quiet <$BASEDIR/request.1 >$BASEDIR/answer.1
-fi;
+  "$BIN_DIR"/osm3s_query --quiet <"$BASEDIR/request.1" >"$BASEDIR/answer.1"
+fi
 
 echo "Content-Type: image/svg+xml; charset=utf-8"
 echo
 
-$BIN_DIR/sketch_route_svg --network="$NETWORK_" --ref="$REF_" $SKETCH_PARAMS <$BASEDIR/answer.1
+# shellcheck disable=SC2086 # SKETCH_PARAMS holds space-separated, validated flags
+"$BIN_DIR"/sketch_route_svg --network="$NETWORK_" --ref="$REF_" $SKETCH_PARAMS <"$BASEDIR/answer.1"
+
+rm -rf "$BASEDIR"

--- a/src/cgi-bin/sketch-options
+++ b/src/cgi-bin/sketch-options
@@ -17,64 +17,82 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PT_Diagrams.  If not, see <http://www.gnu.org/licenses/>.
 
-BUF="$QUERY_STRING&"
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
-# echo "Content-Type: text/plain; charset=utf-8"
-# echo
+STYLE_DIR=/opt/pt_diagrams
+STYLE_RE='[/ ]'
 
-SKETCH_PARAMS=
 ACTION=
 STYLE=
 DATA=
-STYLE_DIR=/opt/pt_diagrams/
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
+fail()
 {
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo
+  echo "$1"
+  exit 0
+}
 
-pushd "$EXEC_DIR" >/dev/null
-
+set -f
 IFS=$'&'
 for KEY_VAL in $QUERY_STRING; do
 {
-  if [[ ${KEY_VAL:0:7} == "action=" ]]; then
-    ACTION="${KEY_VAL:7}"
-  elif [[ ${KEY_VAL:0:6} == "style=" ]]; then
-    STYLE="${KEY_VAL:6}"
-  elif [[ ${KEY_VAL:0:5} == "data=" ]]; then
-    DATA="${KEY_VAL:5}"
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
   fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+  case "$KEY" in
+    action)
+      ACTION="$VAL"
+      ;;
+    style)
+      STYLE="$VAL"
+      ;;
+    data)
+      DATA="$VAL"
+      ;;
+  esac
 }; done
 unset IFS
+set +f
 
-echo "Content-Type: text/html; charset=utf-8\n"
+if [[ $STYLE =~ $STYLE_RE ]]; then
+  fail "Invalid style parameter"
+fi
+
+STYLE_ESCAPED=$(printf '%s' "$STYLE" | "$BIN_DIR"/escape_xml)
+
+echo "Content-Type: text/html; charset=utf-8"
 echo
 
 if [[ $ACTION == "edit" ]]; then
-{
-  echo -e "
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\
-    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\
-<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">
-<head/>\
-<body>\
+  cat <<EOF
 
-<h1>Edit style \"$STYLE\"</h1>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head/>
+<body>
 
-<form action=\"sketch-options\" method=\"get\" accept-charset=\"UTF-8\">
-  <textarea name=\"data\" rows=\"10\" cols=\"80\">"
-  if [[ -r $STYLE_DIR/sketch-line.$STYLE ]]; then
-    ../bin/escape_xml <$STYLE_DIR/sketch-line.$STYLE
+<h1>Edit style "$STYLE_ESCAPED"</h1>
+
+<form action="sketch-options" method="get" accept-charset="UTF-8">
+  <textarea name="data" rows="10" cols="80">
+EOF
+  if [[ -r "$STYLE_DIR/sketch-line.$STYLE" ]]; then
+    "$BIN_DIR"/escape_xml <"$STYLE_DIR/sketch-line.$STYLE"
   fi
-  echo -e "\
+  cat <<EOF
 </textarea>
-  <input type=\"hidden\" name=\"style\" value=\"$STYLE\"/>
-  <input type=\"hidden\" name=\"action\" value=\"commit\"/>
-  <input type=\"submit\"/>
+  <input type="hidden" name="style" value="$STYLE_ESCAPED"/>
+  <input type="hidden" name="action" value="commit"/>
+  <input type="submit"/>
 </form>
 
 <h2>Example file:</h2>
@@ -115,7 +133,7 @@ of street.
 &lt;max-correspondences per-line=&quot;6&quot; below=&quot;0&quot;/&gt;</pre>
 
 These correspond to the options that can be directly passed to sketch-line. They are
-explained at the <a href=\"../public_transport.html\">public transport page</a>.
+explained at the <a href="../public_transport.html">public transport page</a>.
 
 <pre>&lt;correspondences limit=&quot;100&quot;/&gt;</pre>
 
@@ -132,26 +150,24 @@ the text &quot;bank&quot;. A node is nearby if it is less than the corredpondenc
 
 The necessary footer.
 
-</body>\
-"
-};
+</body>
+EOF
 elif [[ $ACTION == "commit" ]]; then
-{
-  echo $DATA | ../bin/uncgi >$STYLE_DIR/sketch-line.$STYLE
-  
-  echo -e "
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
-<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\
-    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\
-<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">
-<head/>\
-<body>\
+  printf '%s' "$DATA" >"$STYLE_DIR/sketch-line.$STYLE"
 
-<h1>Edit style \"$STYLE\"</h1>
+  cat <<EOF
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head/>
+<body>
+
+<h1>Edit style "$STYLE_ESCAPED"</h1>
 
 The style has successfully been saved.
 
-</body>\
-"
-};
+</body>
+EOF
 fi

--- a/src/cgi-bin/sketch-route
+++ b/src/cgi-bin/sketch-route
@@ -17,102 +17,96 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PT_Diagrams.  If not, see <http://www.gnu.org/licenses/>.
 
-ARG_1=`echo $QUERY_STRING | awk -F [=,\&] '{ print $1; }'`
-ARG_2=`echo $QUERY_STRING | awk -F [=,\&] '{ print $2; }'`
-ARG_3=`echo $QUERY_STRING | awk -F [=,\&] '{ print $3; }'`
-ARG_4=`echo $QUERY_STRING | awk -F [=,\&] '{ print $4; }'`
-ARG_5=`echo $QUERY_STRING | awk -F [=,\&] '{ print $5; }'`
-ARG_6=`echo $QUERY_STRING | awk -F [=,\&] '{ print $6; }'`
-ARG_7=`echo $QUERY_STRING | awk -F [=,\&] '{ print $7; }'`
-ARG_8=`echo $QUERY_STRING | awk -F [=,\&] '{ print $8; }'`
+ARG_RE='^[0-9]+$'
 
-BASEDIR=`mktemp -d /tmp/osm3s_sketch_route_XXXXXX`
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
+BASEDIR=
+
+fail()
 {
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo
+  echo "$1"
+  [[ -n $BASEDIR ]] && rm -rf "$BASEDIR"
+  exit 0
+}
+
+ARG_1_RAW=$(printf '%s\n' "$QUERY_STRING" | awk -F '[=,&]' '{ print $1; }')
+ARG_2_RAW=$(printf '%s\n' "$QUERY_STRING" | awk -F '[=,&]' '{ print $2; }')
+ARG_3_RAW=$(printf '%s\n' "$QUERY_STRING" | awk -F '[=,&]' '{ print $3; }')
+
+ARG_1=$(printf '%s' "$ARG_1_RAW" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+ARG_2=$(printf '%s' "$ARG_2_RAW" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+ARG_3=$(printf '%s' "$ARG_3_RAW" | "$BIN_DIR"/uncgi) || fail "Malformed query string"
+
+if [[ -n $ARG_1 && ! $ARG_1 =~ $ARG_RE ]]; then
+  fail "Invalid relation id"
 fi
+
+BASEDIR=$(mktemp -d /tmp/osm3s_sketch_route_XXXXXX) || fail "Could not create temporary directory"
 
 if [[ ( $ARG_2 == "backspace" ) || ($ARG_2 == "backtime") || ($ARG_2 == "debug") ]]; then
-{
-echo -e "\
-<osm-script> \
- \
-<union> \
-  <id-query type=\"relation\" ref=\"$ARG_1\"/> \
-  <recurse type=\"relation-node\"/> \
-</union> \
-<print mode=\"body\"/> \
- \
-</osm-script> \
-" >$BASEDIR/req
-};
+  cat >"$BASEDIR/req" <<EOF
+<osm-script>
+<union>
+  <id-query type="relation" ref="$ARG_1"/>
+  <recurse type="relation-node"/>
+</union>
+<print mode="body"/>
+</osm-script>
+EOF
 elif [[ -n $ARG_2 ]]; then
-{
-echo -e "\
-<osm-script> \
- \
-<union> \
-  <union> \
-    <id-query type=\"relation\" ref=\"$ARG_1\"/> \
-    <id-query type=\"relation\" ref=\"$ARG_2\"/> \
-  </union> \
-  <recurse type=\"relation-node\"/> \
-</union> \
-<print mode=\"body\"/> \
- \
-</osm-script> \
-" >$BASEDIR/req
-};
+  if [[ ! $ARG_2 =~ $ARG_RE ]]; then
+    fail "Invalid relation id"
+  fi
+  cat >"$BASEDIR/req" <<EOF
+<osm-script>
+<union>
+  <union>
+    <id-query type="relation" ref="$ARG_1"/>
+    <id-query type="relation" ref="$ARG_2"/>
+  </union>
+  <recurse type="relation-node"/>
+</union>
+<print mode="body"/>
+</osm-script>
+EOF
 else
-{
-echo -e "\
-<osm-script> \
- \
-<union> \
-  <id-query type=\"relation\" ref=\"$ARG_1\"/> \
-  <recurse type=\"relation-node\"/> \
-</union> \
-<print mode=\"body\"/> \
- \
-</osm-script> \
-" >$BASEDIR/req
-};
+  cat >"$BASEDIR/req" <<EOF
+<osm-script>
+<union>
+  <id-query type="relation" ref="$ARG_1"/>
+  <recurse type="relation-node"/>
+</union>
+<print mode="body"/>
+</osm-script>
+EOF
 fi
 
-REQUEST_METHOD=
-../bin/osm3s_query --quiet --no-mime <$BASEDIR/req >$BASEDIR/result
+export REQUEST_METHOD=
+"$BIN_DIR"/osm3s_query --quiet --no-mime <"$BASEDIR/req" >"$BASEDIR/result"
 
 if [[ $ARG_2 == "backspace" ]]; then
-{
   echo "Content-Type: image/svg+xml; charset=utf-8"
   echo
 
-  #gunzip </tmp/nodes_csv_result.2 | ../bin/sketch_route_svg --backspace
-  ../bin/sketch_route_svg --backspace <$BASEDIR/result
-};
+  "$BIN_DIR"/sketch_route_svg --backspace <"$BASEDIR/result"
 elif [[ $ARG_2 == "backtime" ]]; then
-{
   echo "Content-Type: image/svg+xml; charset=utf-8"
   echo
 
-  #gunzip </tmp/nodes_csv_result.2 | ../bin/sketch_route_svg --backtime
-  ../bin/sketch_route_svg --backtime <$BASEDIR/result
-};
+  "$BIN_DIR"/sketch_route_svg --backtime <"$BASEDIR/result"
 elif [[ ($ARG_2 == "debug") || ($ARG_3 == "debug") ]]; then
-{
   echo "Content-Type: text/plain"
   echo
-  cat <$BASEDIR/result
-};
+  cat "$BASEDIR/result"
 else
-{
   echo "Content-Type: image/svg+xml; charset=utf-8"
   echo
 
-  #gunzip </tmp/nodes_csv_result.2 | ../bin/sketch_route_svg
-  ../bin/sketch_route_svg <$BASEDIR/result
-};
+  "$BIN_DIR"/sketch_route_svg <"$BASEDIR/result"
 fi
+
+rm -rf "$BASEDIR"

--- a/src/cgi-bin/template
+++ b/src/cgi-bin/template
@@ -17,94 +17,116 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
-{
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
-BIN_DIR="$EXEC_DIR/../bin"
-DB_DIR=`../bin/dispatcher --show-dir`
+NAME_RE='^Template:[^/&<>]*$'
+
 ACTION=
 NAME=
 
+bad_request()
+{
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo "Status: 400 Bad Request"
+  echo
+  echo "$1"
+  exit 0
+}
+
+internal_error()
+{
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo "Status: 500 Internal Server Error"
+  echo
+  echo "$1"
+  exit 0
+}
+
+set -f
 IFS=$'&'
 for KEY_VAL in $QUERY_STRING; do
 {
-  if [[ ${KEY_VAL:0:7} == "action=" ]]; then
-    ACTION="${KEY_VAL:7}"
-  elif [[ ${KEY_VAL:0:5} == "name=" ]]; then
-    NAME=`echo "${KEY_VAL:5}" | $BIN_DIR/uncgi`
+  if [[ $KEY_VAL == *=* ]]; then
+    RAW_VAL="${KEY_VAL#*=}"
+  else
+    RAW_VAL=
   fi
+  KEY=$(printf '%s' "${KEY_VAL%%=*}" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
+  VAL=$(printf '%s' "$RAW_VAL" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
+  case "$KEY" in
+    action)
+      ACTION="$VAL"
+      ;;
+    name)
+      NAME="$VAL"
+      ;;
+  esac
 }; done
 unset IFS
+set +f
 
-REQUEST_METHOD=
+if [[ ! $NAME =~ $NAME_RE ]]; then
+  bad_request "Invalid name parameter \"$NAME\": name must start with \"Template:\" and must not contain '/', '&', '<', or '>'"
+fi
+
+DB_DIR=$("$BIN_DIR"/dispatcher --show-dir)
+DB_DIR="$(realpath "$DB_DIR")"
+if [[ ! -d "$DB_DIR" ]]; then
+  internal_error "Could not determine database directory"
+fi
+
+if [[ ! -d "$DB_DIR/templates" ]]; then
+  internal_error "Templates directory is missing; ask the operator to install the default templates"
+fi
+
+NAME_ESCAPED=$(printf '%s' "$NAME" | "$BIN_DIR"/escape_xml)
+
 echo "Content-Type: text/html; charset=utf-8"
 echo
-if [[ ! ${NAME:0:9} == "Template:" ]]; then
-{
-  echo -e "\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n\
-	\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n\
-<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n\
-<head>\n\
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" lang=\"en\"></meta>\n\
-  <title>OSM3S Template</title>\n\
-</head>\n\
-<body>\n\
-\n\
-<p>Template name &quot;$NAME&quot; doesn't start with &quot;Template:&quot;.</p>\n\
-"
-  exit 0
-}; fi
 
 if [[ $ACTION == "show" ]]; then
-{
-  echo -e "\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n\
-	\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n\
-<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n\
-<head>\n\
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" lang=\"en\"></meta>\n\
-  <title>OSM3S Template</title>\n\
-</head>\n\
-<body>\n\
-\n\
-<h1>Template &quot;$NAME&quot;</h1>\n\
-<pre>\n\
-"
-../bin/escape_xml <"$DB_DIR/templates/$NAME"
-echo -e "\
-</pre>\n\
-</body>\n\
-</html>\n\
-\n"
-};
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" lang="en"></meta>
+  <title>OSM3S Template</title>
+</head>
+<body>
+
+<h1>Template "$NAME_ESCAPED"</h1>
+<pre>
+EOF
+  "$BIN_DIR"/escape_xml <"$DB_DIR/templates/$NAME"
+  cat <<EOF
+</pre>
+</body>
+</html>
+
+EOF
 elif [[ $ACTION == "fetch" ]]; then
-{
-  echo -e "\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n\
-	\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n\
-<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n\
-<head>\n\
-  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" lang=\"en\"></meta>\n\
-  <title>OSM3S Template</title>\n\
-</head>\n\
-<body>\n\
-\n\
-<h1>Template &quot;$NAME&quot;</h1>\n\
-<pre>\n\
-"
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" lang="en"></meta>
+  <title>OSM3S Template</title>
+</head>
+<body>
+
+<h1>Template "$NAME_ESCAPED"</h1>
+<pre>
+EOF
   wget -O "$DB_DIR/templates/$NAME" "http://wiki.openstreetmap.org/w/index.php?action=raw&title=$NAME"
-  echo -e "\
-</pre>\n\
-</body>\n\
-</html>\n\
-\n"
-};
+  cat <<EOF
+</pre>
+</body>
+</html>
+
+EOF
 fi

--- a/src/cgi-bin/xapi
+++ b/src/cgi-bin/xapi
@@ -17,47 +17,41 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
-{
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
-BIN_DIR="$EXEC_DIR/../bin"
+DEBUG=
 
-BUF="`echo "$QUERY_STRING" | $BIN_DIR/uncgi`"
-if [[ "${BUF:0:5}" == "debug" ]]; then
-{
-  DEBUG=yes
-  echo "Content-Type: text/plain; charset=utf-8"
-  echo
-  BUF="${BUF:6}"
-  echo "[$BUF]"
-};
-fi
-
-# No mkdir - directory should be created and made world-writeable
-# by the maintainer to allow periodic cleanups.
-XML_REQUEST="`$BIN_DIR/translate_xapi \"${BUF}\"`"
-EXITCODE=$?
-if [[ $EXITCODE -ne 0 ]]; then
+bad_request()
 {
   echo "Content-Type: text/plain; charset=utf-8"
   echo "Status: 400 Bad Request"
   echo
   echo "Error in [$BUF]:"
-  echo "$XML_REQUEST"
-};
-else
-{
-  if [[ $DEBUG == "yes" ]]; then
-  {
-    echo "$XML_REQUEST"
-    echo
-  };
-  fi
-  REQUEST_METHOD=
-  echo "$XML_REQUEST" | ./interpreter
-};
+  echo "$1"
+  exit 0
+}
+
+BUF=$(printf '%s' "$QUERY_STRING" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
+if [[ "${BUF:0:5}" == "debug" ]]; then
+  DEBUG=yes
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo
+  BUF="${BUF:6}"
+  echo "[$BUF]"
 fi
+
+# No mkdir - directory should be created and made world-writeable
+# by the maintainer to allow periodic cleanups.
+XML_REQUEST=$("$BIN_DIR"/translate_xapi "$BUF")
+EXITCODE=$?
+if [[ $EXITCODE -ne 0 ]]; then
+  bad_request "$XML_REQUEST"
+fi
+
+if [[ $DEBUG == "yes" ]]; then
+  printf '%s\n' "$XML_REQUEST"
+  echo
+fi
+export REQUEST_METHOD=
+printf '%s' "$XML_REQUEST" | "$EXEC_DIR"/interpreter

--- a/src/cgi-bin/xapi_meta
+++ b/src/cgi-bin/xapi_meta
@@ -17,47 +17,41 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Overpass_API.  If not, see <http://www.gnu.org/licenses/>.
 
-EXEC_DIR="`dirname $0`/"
-if [[ ! ${EXEC_DIR:0:1} == "/" ]]; then
-{
-  EXEC_DIR="`pwd`/$EXEC_DIR"
-};
-fi
+EXEC_DIR="$(dirname "$(realpath "$0")")"
+BIN_DIR="$(realpath "$EXEC_DIR/../bin")"
 
-BIN_DIR="$EXEC_DIR/../bin"
+DEBUG=
 
-BUF="`echo "$QUERY_STRING" | $BIN_DIR/uncgi`"
-if [[ "${BUF:0:5}" == "debug" ]]; then
-{
-  DEBUG=yes
-  echo "Content-Type: text/plain; charset=utf-8"
-  echo
-  BUF="${BUF:6}"
-  echo "[$BUF]"
-};
-fi
-
-# No mkdir - directory should be created and made world-writeable
-# by the maintainer to allow periodic cleanups.
-XML_REQUEST="`$BIN_DIR/translate_xapi --force-meta \"${BUF}\"`"
-EXITCODE=$?
-if [[ $EXITCODE -ne 0 ]]; then
+bad_request()
 {
   echo "Content-Type: text/plain; charset=utf-8"
   echo "Status: 400 Bad Request"
   echo
   echo "Error in [$BUF]:"
-  echo "$XML_REQUEST"
-};
-else
-{
-  if [[ $DEBUG == "yes" ]]; then
-  {
-    echo "$XML_REQUEST"
-    echo
-  };
-  fi
-  REQUEST_METHOD=
-  echo "$XML_REQUEST" | ./interpreter
-};
+  echo "$1"
+  exit 0
+}
+
+BUF=$(printf '%s' "$QUERY_STRING" | "$BIN_DIR"/uncgi) || bad_request "Malformed query string"
+if [[ "${BUF:0:5}" == "debug" ]]; then
+  DEBUG=yes
+  echo "Content-Type: text/plain; charset=utf-8"
+  echo
+  BUF="${BUF:6}"
+  echo "[$BUF]"
 fi
+
+# No mkdir - directory should be created and made world-writeable
+# by the maintainer to allow periodic cleanups.
+XML_REQUEST=$("$BIN_DIR"/translate_xapi --force-meta "$BUF")
+EXITCODE=$?
+if [[ $EXITCODE -ne 0 ]]; then
+  bad_request "$XML_REQUEST"
+fi
+
+if [[ $DEBUG == "yes" ]]; then
+  printf '%s\n' "$XML_REQUEST"
+  echo
+fi
+export REQUEST_METHOD=
+printf '%s' "$XML_REQUEST" | "$EXEC_DIR"/interpreter

--- a/src/pt_diagrams/uncgi.cc
+++ b/src/pt_diagrams/uncgi.cc
@@ -43,25 +43,25 @@ char hex_digit(char c)
   return 16;
 }
 
-string decode_cgi_to_plain(const string& raw)
+bool decode_cgi_to_plain(const string& raw, string& result)
 {
-  string result;
+  result.clear();
   string::size_type pos(0);
 
   while (pos < raw.size())
   {
     if (raw[pos] == '%')
     {
-      if (pos >= raw.size()+2)
-	return (result + raw.substr(0, pos));
+      if (pos + 2 >= raw.size())
+        return false;
       char a(hex_digit(raw[pos+1])), b(hex_digit(raw[pos+2]));
       if ((a < 16) && (b < 16))
       {
-	result += (char)(a*16 + b);
-	pos += 3;
+        result += (char)(a*16 + b);
+        pos += 3;
       }
       else
-	result += raw[pos++];
+        return false;
     }
     else if (raw[pos] == '+')
     {
@@ -74,20 +74,21 @@ string decode_cgi_to_plain(const string& raw)
       result += raw[pos++];
   }
 
-  return result;
+  return true;
 }
 
 int main(int argc, char *argv[])
 {
   char c;
   string buf;
-  while (!cin.eof())
-  {
-    cin.get(c);
+  while (cin.get(c))
     buf += c;
-  }
 
-  cout<<decode_cgi_to_plain(buf);
+  string result;
+  if (!decode_cgi_to_plain(buf, result))
+    return 1;
+
+  cout<<result;
 
   return 0;
 }


### PR DESCRIPTION
## src/cgi-bin/* (17 scripts)

- Pipe the raw parameter values to `uncgi` on stdin using `printf '%s'` to ensure that they are correctly decoded.
- Resolve the script's own path and relative paths with `realpath` to ensure that path construction is correct.
- Validate parameters before use. Data-API scripts return `400` for a malformed request and `500` only for a missing or unreadable backend file. Scripts that render an HTML page fall back to defaults instead of erroring.
- `sitemap`: fix incorrect handling of an empty directory.
- `ping`: handle error cases and remove a race condition.
- `kill_my_queries`: validate the PID argument; construct paths more carefully.
- Quoting, ShellCheck, and backtick → `$( )` fixes throughout.

Scripts accept the same inputs and produce the same outputs as before for well-formed requests.

## src/pt_diagrams/uncgi.cc

- Properly handle a trailing `%` at the end of the input.
- Restructure main input loop to ensure the entire input is read correctly.

`uncgi` accepts the same inputs and produces the same outputs as before for well-formed requests.
